### PR TITLE
Add an example policy related to attestation data

### DIFF
--- a/policies/examples/attestation_checks.rego
+++ b/policies/examples/attestation_checks.rego
@@ -1,0 +1,21 @@
+package examples.attestation_checks
+
+accepted_attestation_types := ["https://in-toto.io/Statement/v0.1"]
+
+attestation_type_ok(attestation_type) {
+	accepted_attestation_types[_] = attestation_type
+}
+
+deny = {"msg": msg} {
+	not attestation_type_ok(data.attestation._type)
+
+	quoted_list := [quoted_type |
+		t := accepted_attestation_types[_]
+		quoted_type := sprintf("'%s'", [t])
+	]
+
+	msg := sprintf(
+		"Invalid value in attestation _type field: '%s'. Expecting one of the following: %s",
+		[data.attestation._type, concat(", ", quoted_list)],
+	)
+}

--- a/policies/examples/attestation_checks_test.rego
+++ b/policies/examples/attestation_checks_test.rego
@@ -1,0 +1,30 @@
+package examples.attestation_checks
+
+# This is a fragment of an attestation
+# (I can't figure out how use the real file in a test...)
+#
+mock_data := {
+	"_type": "https://in-toto.io/Statement/v0.1",
+	"predicateType": "https://slsa.dev/provenance/v0.2",
+	"predicate": {
+		"builder": {"id": "https://tekton.dev/chains/v2"},
+		"buildType": "https://tekton.dev/attestations/chains@v2",
+	},
+}
+
+# Test the lower level function
+test_attestation_type_ok {
+	attestation_type_ok("https://in-toto.io/Statement/v0.1")
+	not attestation_type_ok("http://in-toto.io/Statement/v0.1")
+	not attestation_type_ok("foo")
+}
+
+# Test the deny rule
+test_attestation_type_validation {
+	# To begin with the attestation is valid so it should not deny
+	not deny with data.attestation as mock_data
+
+	# With a bad type value it should deny
+	expected_msg := "Invalid value in attestation _type field: 'badtype'. Expecting one of the following: 'https://in-toto.io/Statement/v0.1'"
+	deny == {"msg": expected_msg} with data.attestation as object.union(mock_data, {"_type": "badtype"})
+}


### PR DESCRIPTION
I'm aiming to create a set of useful and tested examples that can
serve as a reference when we do write the real policies.

This example shows how to use some mocked data and write some test
coverage for a more realistic rule.