### PR TITLE
Makefile action for fetching registry attestations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,24 @@ help:
 	@echo "  make test         # Run all tests"
 	@echo "  make fmt          # Apply default formatting to all rego files"
 	@echo "  make ci           # Check formatting and run all tests"
+	@echo "  make coverage     # Show which lines of rego are not covered by tests"
+	@echo
 	@echo "  make install-opa  # Install opa if you don't have it already (Linux only)"
+	@echo
+	@echo "  make fetch-att    # Fetch an attestation for an image"
+	@echo "                    # Add \`IMAGE=<someimage>\` to fetch a specific attestation"
+	@echo "                    # Note: This is compatible with the 'verify-enterprise-contract' task"
+	@echo
 	@echo "  make fetch-data   # Fetch data for the most recent pipeline run"
-	@echo "                    # Add \`PR=prname\` to fetch a specific pipeline run"
+	@echo "                    # Add \`PR=<prname>\` to fetch a specific pipeline run"
+	@echo "                    # Note: This is compatible with the deprecated 'enterprise-contract' task"
+	@echo "                    # and requires the build-definitions repo checked out in ../build-definitions"
+	@echo
 	@echo "  make show-files   # List data files"
 	@echo "  make show-data    # Show all data visible to opa in one big object"
 	@echo "  make show-keys    # List all the keys in the data"
+	@echo
 	@echo "  make check        # Check rego policies against the fetched data"
-	@echo "  make coverage     # Show which lines of code are not covered by tests"
 
 test:
 	@opa test . -v
@@ -39,6 +49,38 @@ fmt-check:
 # For convenience. If this passes then it should pass in GitHub
 ci: fmt-check quiet-test
 
+#--------------------------------------------------------------------
+
+clean-data:
+	@rm -rf $(DATA_DIR)
+
+# Avoid a "feels like a bad day.." violation
+dummy-config:
+	@mkdir -p $(DATA_DIR)/config/policy
+	@echo '{"non_blocking_checks":["not_useful"]}' | jq > $(DATA_DIR)/config/policy/data.json
+
+# Set IMAGE as required like this:
+#   make fetch-attestation IMAGE=<someimage>
+#
+# The format and file path is intended to match what is used in the
+# verify-attestation-with-policy script in the build-definitions repo
+# so you can test your rules as they would be applied by the
+# verify-enterprise-contract task.
+#
+ifndef IMAGE
+  # Default value for convenience/laziness. You're encouraged to specify your own IMAGE.
+  # (The default has no special significance other than it's known to have an attestation.)
+  IMAGE="quay.io/lucarval/tekton-test@sha256:3dde9d48a4ba03187d7a7f5768672fd1bc0eda754afaf982f0768983bb95a06f"
+endif
+
+fetch-att: clean-data dummy-config
+	@mkdir -p $(DATA_DIR)/attestations
+	cosign download attestation $(IMAGE) | \
+	  jq -s '[.[].payload | @base64d | fromjson]' > \
+	    $(DATA_DIR)/attestations/data.json
+
+#--------------------------------------------------------------------
+
 # Assume you have the build-definitions repo checked out close by
 #
 THIS_DIR=$(shell git rev-parse --show-toplevel)
@@ -60,6 +102,8 @@ $(eval $(call BD_SCRIPT,show,yaml))
 show-data: show-yaml
 fetch-data: fetch-
 
+#--------------------------------------------------------------------
+
 POLICIES_DIR=$(THIS_DIR)/policies
 OPA_FORMAT=pretty
 OPA_QUERY=data.hacbs.contract.main.deny
@@ -70,12 +114,14 @@ check:
 	  --format $(OPA_FORMAT) \
 	  $(OPA_QUERY)
 
+#--------------------------------------------------------------------
+
 OPA_VER=v0.39.0
 OPA_FILE=opa_linux_amd64_static
 OPA_URL=https://openpolicyagent.org/downloads/$(OPA_VER)/$(OPA_FILE)
 OPA_SHA=19a24f51d954190c02aafeac5867c9add286c6ab12ea85b3d8d348c98d633319
 ifndef OPA_BIN
-	OPA_BIN=$(HOME)/bin
+  OPA_BIN=$(HOME)/bin
 endif
 OPA_DEST=$(OPA_BIN)/opa
 
@@ -87,4 +133,7 @@ install-opa:
 	chmod 755 $(OPA_DEST)
 	rm $(OPA_FILE)
 
-.PHONY: help test fmt fmt-check ci install-opa fetch-data show-data check
+#--------------------------------------------------------------------
+
+.PHONY: help test fmt fmt-check ci install-opa check \
+  clean-data dummy-config fetch-att fetch-data show-data

--- a/policies/lib/config.rego
+++ b/policies/lib/config.rego
@@ -15,4 +15,5 @@ allowed_registries := [
 	"registry.access.redhat.com/ubi8-minimal",
 	"registry.redhat.io/openshift-pipelines",
 	"registry.redhat.io/openshift4",
+	"quay.io/buildah",
 ]


### PR DESCRIPTION
So we can conveniently test these rego rules for hacking purposes.

It uses cosign download to avoid needing to provide the public signing
key, which would be needed if we did a cosign verify-attestation.

Also:
- Throw in the dummy policy config so we skip the not useful test,
  (which is also what happens in the related task in the
  build-definitions repo)
- Pretty up the makefile a little and mention the new tasks in the
  help
- Add quay.io/buildah just to make the default attestation pass
  the policy check
- Some todo commentary about the repo matching since I realized it
  would generally match on organization (in quay.io at least) rather
  than a repo. That could be a feature, but it's not described well.

Note:
- The file path data/attestations.json would work the same as
  data/attestations/data.json from opa's perspective, but this way
  is more consistent with how it's done elsewhere.
- I chose to keep the older fetch-data scripts intact rather than
  clean them up, even though we're considering them deprecated.
  This follows the approach from the build-definitions repo, and
  also there might be some use for the them as we start working on
  other kinds of policies such as validating pipeline definitions
  or ApplicationSnapshot CRs.