### PR TITLE
Policy for asserting test output

### DIFF
--- a/policies/main.rego
+++ b/policies/main.rego
@@ -3,6 +3,7 @@ package hacbs.contract.main
 import data.hacbs.contract.attestation_type
 import data.hacbs.contract.not_useful
 import data.hacbs.contract.step_image_registries
+import data.hacbs.contract.test
 
 deny[msg] {
 	not skip("attestation_type")
@@ -17,6 +18,11 @@ deny[msg] {
 deny[msg] {
 	not skip("not_useful")
 	count(not_useful.deny[msg]) > 0
+}
+
+deny[msg] {
+	not skip("test")
+	count(test.deny[msg]) > 0
 }
 
 skip(test_name) {

--- a/policies/main_test.rego
+++ b/policies/main_test.rego
@@ -1,12 +1,29 @@
 package hacbs.contract.main
 
+all_tests := {"chains_config", "cluster_sanity", "transparency_urls", "transparency_log_attestations", "not_useful", "test"}
+
 test_main {
 	deny with data.hacbs.contract.attestation_type.deny as {{"msg": "foo"}}
 	deny with data.hacbs.contract.step_image_registries.deny as {{"msg": "foo"}}
 	deny with data.hacbs.contract.not_useful.deny as {{"msg": "foo"}} with data.config.policy.non_blocking_checks as []
 }
 
-test_skipping {
-	skip("attestation_type") with data.config.policy.non_blocking_checks as ["attestation_type"]
-	not skip("attestation_type") with data.config.policy.non_blocking_checks as []
+test_failing_without_skipping {
+	count(deny) > 0 with data.config.policy as {"non_blocking_checks": {}}
+}
+
+test_succeeding_when_skipping_all {
+	count(deny) == 0 with data.config.policy as {"non_blocking_checks": all_tests}
+}
+
+test_test_can_be_skipped {
+	count(deny) > 0 with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
+}
+
+test_test_succeeds {
+	count(deny) == 0 with data.test as [{"result": "SUCCESS"}] with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
+}
+
+test_test_fails {
+	count(deny) > 0 with data.test as [{"result": "FAILURE"}] with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
 }

--- a/policies/test.rego
+++ b/policies/test.rego
@@ -1,0 +1,28 @@
+package hacbs.contract.test
+
+# Check if we have any test data is present
+deny[{"msg": msg}] {
+	not data.test
+	msg := "No test data provided"
+}
+
+# Check if we have any test data provided
+deny[{"msg": msg}] {
+	count(data.test) == 0
+	msg := "Empty test data provided"
+}
+
+deny[{"msg": msg}] {
+	with_results := [result | result := data.test[_].result]
+	count(with_results) != count(data.test)
+
+	msg := "Found tests without results"
+}
+
+# Check if all tests succeeded 
+deny[{"msg": msg}] {
+	all_failed := [failure | data.test[_].result != "SUCCESS"; failure := 1]
+	count(all_failed) > 0
+
+	msg := "All tests did not end with SUCCESS"
+}

--- a/policies/test_test.rego
+++ b/policies/test_test.rego
@@ -1,0 +1,33 @@
+package hacbs.contract.test
+
+test_needs_to_have_data {
+	deny == {{"msg": "No test data provided"}}
+}
+
+test_needs_non_empty_data {
+	deny == {{"msg": "Empty test data provided"}} with data.test as []
+}
+
+test_needs_tests_with_results {
+	deny == {{"msg": "Found tests without results"}} with data.test as [{}]
+}
+
+test_needs_tests_with_results_mixed {
+	deny == {{"msg": "Found tests without results"}} with data.test as [{}, {"result": "SUCCESS"}]
+}
+
+test_success_data {
+	count(deny) == 0 with data.test as [{"result": "SUCCESS"}]
+}
+
+test_failure_data {
+	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test as [{"result": "FAILURE"}]
+}
+
+test_error_data {
+	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test as [{"result": "ERROR"}]
+}
+
+test_mix_data {
+	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test as [{"result": "SUCCESS"}, {"result": "FAILURE"}, {"result": "ERROR"}]
+}


### PR DESCRIPTION
This is the simplest policy for asserting the test stream's output. Two
rules are provided: that there is some test data available and that
all[1] data indicates successful outcome.

Ref. https://issues.redhat.com/browse/HACBS-340

[1]there are more than one test data JSON files, currently at two for
`sanity-inspect-image` and `sanity-label-check` tasks.