### PR TITLE
Nested rule unblocking when asserting test data

### DIFF
--- a/policies/test.rego
+++ b/policies/test.rego
@@ -21,8 +21,20 @@ deny[{"msg": msg}] {
 
 # Check if all tests succeeded 
 deny[{"msg": msg}] {
-	all_failed := [failure | data.test[_].result != "SUCCESS"; failure := 1]
-	count(all_failed) > 0
+	# Collect all failed tests and convert their name to "test:<name>" format
+	# Reminder: the tests reside in $DATA_DIR/test/<name>/data.json
+	all_failed := {failure | data.test[name].result != "SUCCESS"; failure := sprintf("test:%s", [name])}
+
+	# For the complement operation below (subtraction) we need
+	# non_blocking_checks as set and this creates that from the array
+	non_blocking_set = {x | x := data.config.policy.non_blocking_checks[_]}
+
+	# Failed tests are those that don't have their result equal to "SUCCESS"
+	# and are not on the list of non_blocking_checks
+	failed_blocking := all_failed - non_blocking_set
+
+	# Fail if there are any
+	count(failed_blocking) > 0
 
 	msg := "All tests did not end with SUCCESS"
 }

--- a/policies/test_test.rego
+++ b/policies/test_test.rego
@@ -13,21 +13,32 @@ test_needs_tests_with_results {
 }
 
 test_needs_tests_with_results_mixed {
-	deny == {{"msg": "Found tests without results"}} with data.test as [{}, {"result": "SUCCESS"}]
+	deny == {{"msg": "Found tests without results"}} with data.test as [{}, {"test1": {"result": "SUCCESS"}}]
 }
 
 test_success_data {
-	count(deny) == 0 with data.test as [{"result": "SUCCESS"}]
+	count(deny) == 0 with data.test.test1 as {"result": "SUCCESS"}
+		with data.config.policy as {"non_blocking_checks": []}
 }
 
 test_failure_data {
-	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test as [{"result": "FAILURE"}]
+	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test.test1 as {"result": "FAILURE"}
+		with data.config.policy as {"non_blocking_checks": []}
 }
 
 test_error_data {
-	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test as [{"result": "ERROR"}]
+	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test.test1 as {"result": "ERROR"}
+		with data.config.policy as {"non_blocking_checks": []}
 }
 
 test_mix_data {
-	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test as [{"result": "SUCCESS"}, {"result": "FAILURE"}, {"result": "ERROR"}]
+	deny == {{"msg": "All tests did not end with SUCCESS"}} with data.test.successfull as {"result": "SUCCESS"}
+		with data.test.failed as {"result": "FAILURE"}
+		with data.test.errored as {"result": "ERROR"}
+		with data.config.policy as {"non_blocking_checks": []}
+}
+
+test_can_skip_by_name {
+	count(deny) == 0 with data.test.test1 as {"result": "FAILURE"}
+		with data.config.policy as {"non_blocking_checks": ["test:test1"]}
 }


### PR DESCRIPTION
With this we can pass the Enterprise Contract checks not only when asserting the whole test data, but also for parts of the test data.

Previously we could set:

    data.config.policy.non_blocking_checks: ["test"]

To disregard asserting all test data.

Now we can also disregard asserting parts of the test data, e.g. for `conftest-clair` we can now set:

    data.config.policy.non_blocking_checks: ["test:conftest-clair"]

Ref. https://issues.redhat.com/browse/HACBS-360