### PR TITLE
Nicer coverage threshold not met message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+COVERAGE = @opa test . --threshold 100 2>&1 | sed -e '/^Code coverage/!d' -e 's/^/ERROR: /'; exit $${PIPESTATUS[0]}
 
 help:
 	@echo "Usage:"
@@ -25,7 +27,7 @@ help:
 
 test:
 	@opa test . -v
-	@opa test . --threshold 100 >/dev/null 2>&1
+	$(COVERAGE)
 
 # Show which lines of code are not covered
 coverage:
@@ -33,7 +35,7 @@ coverage:
 
 quiet-test:
 	@opa test .
-	@opa test . --threshold 100 >/dev/null 2>&1
+	$(COVERAGE)
 
 # Do `dnf install entr` then run this a separate terminal or split window while hacking
 live-test:


### PR DESCRIPTION
We deliberately dropped the output of `opa test --threshold ...` as when the test coverage target is met `opa` will output a large JSON file with the coverage detail.

If the `make test` fails on the test coverage not being met it fails with this message:

```
...
PASS: 26/26
make: *** [Makefile:28: test] Error 2
```

This could lead to confusion about what actually failed, so with this in such cases the message is now:

```
...
PASS: 26/26
ERROR: Code coverage threshold not met: got 99.35 instead of 100.00
make: *** [Makefile:28: test] Error 2
```