### PR TITLE
Refactor to generalize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ fetch-data: fetch-
 
 POLICIES_DIR=$(THIS_DIR)/policies
 OPA_FORMAT=pretty
-OPA_QUERY=data.hacbs.contract.main.deny
+OPA_QUERY=data.main.deny
 check:
 	@opa eval \
 	  --data $(DATA_DIR) \

--- a/policies/attestation_type.rego
+++ b/policies/attestation_type.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.attestation_type
+package hacbs.contract.policies.attestation_type
 
 import data.lib
 

--- a/policies/attestation_type.rego
+++ b/policies/attestation_type.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.attestation_type
+package policies.attestation_type
 
 import data.lib
 

--- a/policies/attestation_type_test.rego
+++ b/policies/attestation_type_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.attestation_type
+package policies.attestation_type
 
 test_attestation_type_ok {
 	attestation_type_valid("https://in-toto.io/Statement/v0.1")

--- a/policies/attestation_type_test.rego
+++ b/policies/attestation_type_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.attestation_type
+package hacbs.contract.policies.attestation_type
 
 test_attestation_type_ok {
 	attestation_type_valid("https://in-toto.io/Statement/v0.1")

--- a/policies/main.rego
+++ b/policies/main.rego
@@ -1,28 +1,9 @@
 package hacbs.contract.main
 
-import data.hacbs.contract.attestation_type
-import data.hacbs.contract.not_useful
-import data.hacbs.contract.step_image_registries
-import data.hacbs.contract.test
-
-deny[msg] {
-	not skip("attestation_type")
-	count(attestation_type.deny[msg]) > 0
-}
-
-deny[msg] {
-	not skip("step_image_registries")
-	count(step_image_registries.deny[msg]) > 0
-}
-
-deny[msg] {
-	not skip("not_useful")
-	count(not_useful.deny[msg]) > 0
-}
-
-deny[msg] {
-	not skip("test")
-	count(test.deny[msg]) > 0
+deny = {denial |
+	not skip(policy)
+	data.hacbs.contract.policies[policy].deny[_]
+	denial := data.hacbs.contract.policies[policy].deny[_]
 }
 
 skip(test_name) {

--- a/policies/main.rego
+++ b/policies/main.rego
@@ -1,9 +1,9 @@
-package hacbs.contract.main
+package main
 
 deny = {denial |
 	not skip(policy)
-	data.hacbs.contract.policies[policy].deny[_]
-	denial := data.hacbs.contract.policies[policy].deny[_]
+	data.policies[policy].deny[_]
+	denial := data.policies[policy].deny[_]
 }
 
 skip(test_name) {

--- a/policies/main_test.rego
+++ b/policies/main_test.rego
@@ -1,11 +1,11 @@
-package hacbs.contract.main
+package main
 
-all_tests := {p | data.hacbs.contract.policies[policy]; p := policy}
+all_tests := {p | data.policies[policy]; p := policy}
 
 test_main {
-	deny with data.hacbs.contract.attestation_type.deny as {{"msg": "foo"}}
-	deny with data.hacbs.contract.step_image_registries.deny as {{"msg": "foo"}}
-	deny with data.hacbs.contract.not_useful.deny as {{"msg": "foo"}} with data.config.policy.non_blocking_checks as []
+	deny with data.attestation_type.deny as {{"msg": "foo"}}
+	deny with data.step_image_registries.deny as {{"msg": "foo"}}
+	deny with data.not_useful.deny as {{"msg": "foo"}} with data.config.policy.non_blocking_checks as []
 }
 
 test_failing_without_skipping {

--- a/policies/main_test.rego
+++ b/policies/main_test.rego
@@ -1,6 +1,6 @@
 package hacbs.contract.main
 
-all_tests := {"chains_config", "cluster_sanity", "transparency_urls", "transparency_log_attestations", "not_useful", "test"}
+all_tests := {p | data.hacbs.contract.policies[policy]; p := policy}
 
 test_main {
 	deny with data.hacbs.contract.attestation_type.deny as {{"msg": "foo"}}
@@ -9,7 +9,10 @@ test_main {
 }
 
 test_failing_without_skipping {
-	count(deny) > 0 with data.config.policy as {"non_blocking_checks": {}}
+	# Let's make sure that the contract remains the same by checking what `deny` is set to
+	# this makes this test a bit more fragile, but the assertion is better as we know that
+	# the output hasn't changed it's shape
+	{{"msg": "It just feels like a bad day to do a release"}, {"msg": "No test data provided"}} == deny with data.config.policy as {"non_blocking_checks": {}}
 }
 
 test_succeeding_when_skipping_all {
@@ -17,7 +20,7 @@ test_succeeding_when_skipping_all {
 }
 
 test_test_can_be_skipped {
-	count(deny) > 0 with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
+	{{"msg": "No test data provided"}} == deny with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
 }
 
 test_test_succeeds {
@@ -25,5 +28,5 @@ test_test_succeeds {
 }
 
 test_test_fails {
-	count(deny) > 0 with data.test as [{"result": "FAILURE"}] with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
+	{{"msg": "All tests did not end with SUCCESS"}} == deny with data.test as [{"result": "FAILURE"}] with data.config.policy as {"non_blocking_checks": all_tests - {"test"}}
 }

--- a/policies/not_useful.rego
+++ b/policies/not_useful.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.not_useful
+package policies.not_useful
 
 #
 # This is demoing the concept of being able to conveniently exclude

--- a/policies/not_useful.rego
+++ b/policies/not_useful.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.not_useful
+package hacbs.contract.policies.not_useful
 
 #
 # This is demoing the concept of being able to conveniently exclude

--- a/policies/not_useful_test.rego
+++ b/policies/not_useful_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.not_useful
+package policies.not_useful
 
 test_not_useful {
 	count(deny) == 1

--- a/policies/not_useful_test.rego
+++ b/policies/not_useful_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.not_useful
+package hacbs.contract.policies.not_useful
 
 test_not_useful {
 	count(deny) == 1

--- a/policies/step_image_registries.rego
+++ b/policies/step_image_registries.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.step_image_registries
+package policies.step_image_registries
 
 import data.lib
 

--- a/policies/step_image_registries.rego
+++ b/policies/step_image_registries.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.step_image_registries
+package hacbs.contract.policies.step_image_registries
 
 import data.lib
 

--- a/policies/step_image_registries_test.rego
+++ b/policies/step_image_registries_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.step_image_registries
+package policies.step_image_registries
 
 good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 

--- a/policies/step_image_registries_test.rego
+++ b/policies/step_image_registries_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.step_image_registries
+package hacbs.contract.policies.step_image_registries
 
 good_image := "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:af7dd5b3b"
 

--- a/policies/test.rego
+++ b/policies/test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.test
+package policies.test
 
 # Check if we have any test data is present
 deny[{"msg": msg}] {

--- a/policies/test.rego
+++ b/policies/test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.test
+package hacbs.contract.policies.test
 
 # Check if we have any test data is present
 deny[{"msg": msg}] {

--- a/policies/test_test.rego
+++ b/policies/test_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.test
+package hacbs.contract.policies.test
 
 test_needs_to_have_data {
 	deny == {{"msg": "No test data provided"}}

--- a/policies/test_test.rego
+++ b/policies/test_test.rego
@@ -1,4 +1,4 @@
-package hacbs.contract.policies.test
+package policies.test
 
 test_needs_to_have_data {
 	deny == {{"msg": "No test data provided"}}


### PR DESCRIPTION
This moves the policy rules to `policies` package so we can generalize over all policies. That is, in `main` we no longer need to call out each policy by name.
The test for main is now a bit more fragile as changes to the policies could fail the test, this is to assert that the output from main hasn't changed in it's shape (say from a set to an array).