### PR TITLE
Run `opa check` in strict mode

### DIFF
--- a/.github/workflows/pre-merge-ci.yaml
+++ b/.github/workflows/pre-merge-ci.yaml
@@ -22,8 +22,5 @@ jobs:
     - name: Install opa
       run: make install-opa OPA_BIN=$HOME/.local/bin
 
-    - name: Validate formatting
-      run: make fmt-check
-
-    - name: Run tests
-      run: make test
+    - name: Run checks
+      run: make ci

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,11 @@ fmt-check:
 	@opa fmt . --list | xargs -r -n1 echo 'Incorrect formatting found in'
 	@opa fmt . --list --fail >/dev/null 2>&1
 
+opa-check:
+	@opa check . --strict
+
 # For convenience. If this passes then it should pass in GitHub
-ci: fmt-check quiet-test
+ci: fmt-check quiet-test opa-check
 
 #--------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ fmt-check:
 opa-check:
 	@opa check . --strict
 
-# For convenience. If this passes then it should pass in GitHub
 ci: fmt-check quiet-test opa-check
 
 #--------------------------------------------------------------------


### PR DESCRIPTION
Additional check we can make is to run `opa check`, this adds it as a
rule to the Makefile and refactors the GitHub workflow to run the `ci`
rule. There are a few[1] strict checks that are currently enforced.

The difference in running the `ci` rule is that instead of `test`
`test-quiet` is invoked.

[1] https://www.openpolicyagent.org/docs/latest/strict/