### PR TITLE
Nicer `make help` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,77 +1,88 @@
 SHELL := /bin/bash
 COVERAGE = @opa test . --threshold 100 2>&1 | sed -e '/^Code coverage/!d' -e 's/^/ERROR: /'; exit $${PIPESTATUS[0]}
 
-help:
-	@echo "Usage:"
-	@echo "  make test         # Run all tests"
-	@echo "  make fmt          # Apply default formatting to all rego files"
-	@echo "  make ci           # Check formatting and run all tests"
-	@echo "  make coverage     # Show which lines of rego are not covered by tests"
-	@echo
-	@echo "  make install-opa  # Install opa if you don't have it already (Linux only)"
-	@echo
-	@echo "  make fetch-att    # Fetch an attestation for an image"
-	@echo "                    # Add \`IMAGE=<someimage>\` to fetch a specific attestation"
-	@echo "                    # Note: This is compatible with the 'verify-enterprise-contract' task"
-	@echo
-	@echo "  make fetch-data   # Fetch data for the most recent pipeline run"
-	@echo "                    # Add \`PR=<prname>\` to fetch a specific pipeline run"
-	@echo "                    # Note: This is compatible with the deprecated 'enterprise-contract' task"
-	@echo "                    # and requires the build-definitions repo checked out in ../build-definitions"
-	@echo
-	@echo "  make show-files   # List data files"
-	@echo "  make show-data    # Show all data visible to opa in one big object"
-	@echo "  make show-keys    # List all the keys in the data"
-	@echo
-	@echo "  make check        # Check rego policies against the fetched data"
+##@ General
 
-test:
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'function ww(s) {\
+		if (length(s) < 59) {\
+			return s;\
+		}\
+		else {\
+			r="";\
+			l="";\
+			split(s, arr, " ");\
+			for (w in arr) {\
+				if (length(l " " arr[w]) > 59) {\
+					r=r l "\n                     ";\
+					l="";\
+				}\
+				l=l " " arr[w];\
+			}\
+			r=r l;\
+			return r;\
+		}\
+	} BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", "make " $$1, ww($$2) } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+test: ## Run all tests in verbose mode and check coverage
 	@opa test . -v
 	$(COVERAGE)
 
-# Show which lines of code are not covered
-coverage:
+coverage: ## Show which lines of rego are not covered by tests
 	@opa test . --coverage --format json | jq -r '.files | to_entries | map("\(.key): Uncovered:\(.value.not_covered)") | .[]' | grep -v "Uncovered:null"
 
-quiet-test:
+quiet-test: ## Run all tests in quiet mode and check coverage
 	@opa test .
 	$(COVERAGE)
 
 # Do `dnf install entr` then run this a separate terminal or split window while hacking
-live-test:
+live-test: ## Continuously run tests on changes to any `*.rego` files, `entr` needs to be installed
 	@trap exit SIGINT; \
 	while true; do \
 	  git ls-files -c -o '*.rego' | entr -d -c $(MAKE) --no-print-directory quiet-test; \
 	done
 
-# Rewrite all rego files with the preferred format
-# Use before you commit
-fmt:
+fmt: ## Apply default formatting to all rego files. Use before you commit
 	@opa fmt . --write
 
-# Return non-zero exit code if formatting is needed
-# Used in CI
-fmt-check:
+opa-check: ## Check Rego files with strict mode (https://www.openpolicyagent.org/docs/latest/strict/)
+	@opa check . --strict
+
+##@ CI
+
+fmt-check: ## Check formatting of Rego files. Used in CI.
 	@opa fmt . --list | xargs -r -n1 echo 'Incorrect formatting found in'
 	@opa fmt . --list --fail >/dev/null 2>&1
 
-opa-check:
-	@opa check . --strict
-
-ci: fmt-check quiet-test opa-check
+ci: fmt-check quiet-test opa-check ## Runs all checks and tests. Used in CI.
 
 #--------------------------------------------------------------------
 
-clean-data:
+##@ Data helpers
+
+clean-data: ## Removes everything from the `./data` directory
 	@rm -rf $(DATA_DIR)
 
-# Avoid a "feels like a bad day.." violation
-dummy-config:
+dummy-config: ## Changes the configuration to mark the `not_useful` check as non-blocking to avoid a "feels like a bad day.." violation
 	@mkdir -p $(DATA_DIR)/config/policy
 	@echo '{"non_blocking_checks":["not_useful"]}' | jq > $(DATA_DIR)/config/policy/data.json
 
 # Set IMAGE as required like this:
-#   make fetch-attestation IMAGE=<someimage>
+#   make fetch-att IMAGE=<someimage>
 #
 # The format and file path is intended to match what is used in the
 # verify-attestation-with-policy script in the build-definitions repo
@@ -84,7 +95,7 @@ ifndef IMAGE
   IMAGE="quay.io/lucarval/tekton-test@sha256:3dde9d48a4ba03187d7a7f5768672fd1bc0eda754afaf982f0768983bb95a06f"
 endif
 
-fetch-att: clean-data dummy-config
+fetch-att: clean-data dummy-config ## Fetches attestation data for IMAGE, use `make fetch-att IMAGE=<ref>`. Note: This is compatible with the 'verify-enterprise-contract' task
 	@mkdir -p $(DATA_DIR)/attestations
 	cosign download attestation $(IMAGE) | \
 	  jq -s '[.[].payload | @base64d | fromjson]' > \
@@ -110,15 +121,17 @@ $(eval $(call BD_SCRIPT,show,keys))
 $(eval $(call BD_SCRIPT,show,json))
 $(eval $(call BD_SCRIPT,show,yaml))
 
-show-data: show-yaml
-fetch-data: fetch-
+show-data: show-yaml ## Dump available data in `./data` as YAML
+fetch-data: fetch- ## Fetch data for the most recent pipeline run. Add `PR=<prname>` to fetch a specific pipeline run. Note: This is compatible with the deprecated 'enterprise-contract' task and requires the build-definitions repo checked out in ../build-definitions
 
 #--------------------------------------------------------------------
+
+##@ Running
 
 POLICIES_DIR=$(THIS_DIR)/policies
 OPA_FORMAT=pretty
 OPA_QUERY=data.main.deny
-check:
+check: ## Run policy evaluation with currently fetched data in `./data` and policy rules in `./policies`
 	@opa eval \
 	  --data $(DATA_DIR) \
 	  --data $(POLICIES_DIR) \
@@ -142,7 +155,9 @@ ifndef OPA_BIN
 endif
 OPA_DEST=$(OPA_BIN)/opa
 
-install-opa:
+##@ Utility
+
+install-opa: ## Install `opa` CLI from GitHub releases
 	curl -s -L -O $(OPA_URL)
 	echo "$(OPA_SHA) $(OPA_FILE)" | sha256sum --check
 	mkdir -p $(OPA_BIN)


### PR DESCRIPTION
This is stolen from the Makefile generated by kubebuilder. The `help` rule now runs `awk` over the Makefile and interprets `#@` and `##` comments to determine categories and descriptions of rules. This way we don't need to update the text in the `help` rule and the description of the rule is now inline with the rule itself.

Output now looks like:

```
make help

Usage:
  make <target>

General
  help             Display this help.

Development
  test             Run all tests in verbose mode and check coverage
  coverage         Show which lines of rego are not covered by tests
  quiet-test       Run all tests in quiet mode and check coverage
  live-test        Continuously run tests on changes to any `*.rego` files, `entr` needs to be installed
  fmt              Apply default formatting to all rego files. Use before you commit
  opa-check        Check Rego files with strict mode (https://www.openpolicyagent.org/docs/latest/strict/)

CI
  fmt-check        Check formatting of Rego files. Used in CI.
  ci               Runs all checks and tests. Used in CI.

Data helpers
  clean-data       Removes everything from the `./data` directory
  dummy-config     Changes the configuration to mark the `not_useful` check as non-blocking to avoid a "feels like a bad day.." violation
  fetch-att        Fetches attestation data for IMAGE, use `make fetch-att IMAGE=<ref>`. Note: This is compatible with the 'verify-enterprise-contract' task
  show-data        Dump available data in `./data` as YAML
  fetch-data       Fetch data for the most recent pipeline run. Add `PR=<prname>` to fetch a specific pipeline run. Note: This is compatible with the deprecated 'enterprise-contract' task and requires the build-definitions repo checked out in ../build-definitions

Running
  check            Run policy evaluation with currently fetched data in `./data` and policy rules in `./policies`

Utility
  install-opa      Install `opa` CLI from GitHub releases
```