### PR TITLE
Use annotations as the source of effective_on date

### DIFF
--- a/policies/examples/time_base_test.rego
+++ b/policies/examples/time_base_test.rego
@@ -3,19 +3,27 @@
 # package under test by name in these particular tests.
 package examples.time_based_test
 
+in_the_future := {"msg": "Roads?", "effective_on": "2099-05-02T00:00:00Z"}
+
+no_effective_date := {"msg": "no effective date"}
+
+in_the_past := {"msg": "from the past", "effective_on": "1970-01-01T01:00:00Z"}
+
 test_not_effective_by_default {
 	# The time based filtering happens automatically on the real polices. Replace
 	# those with our example policy.
-	set() == data.main.deny with data.policies as {data.examples.time_based}
+	# time_based policy has effective_on far into the future, if you're reading
+	# this then bump it for another 100 years
+	{no_effective_date, in_the_past} == data.main.deny with data.policies as {data.examples.time_based}
 		with data.config.policy.non_blocking_checks as []
 }
 
 test_effective_with_time_travel {
 	# Set the date/time to the future where the example policy becomes effective.
-	policy_config := {"non_blocking_checks": [], "when_ns": data.examples.time_based.effective_on}
+	policy_config := {"non_blocking_checks": [], "when_ns": time.parse_rfc3339_ns("2099-05-02T00:00:00Z")}
 
 	# The time based filtering happens automatically on the real polices. Replace
 	# those with our example policy.
-	{{"msg": "Roads?"}} == data.main.deny with data.policies as {data.examples.time_based}
+	{in_the_future, no_effective_date, in_the_past} == data.main.deny with data.policies as {data.examples.time_based}
 		with data.config.policy as policy_config
 }

--- a/policies/examples/time_base_test.rego
+++ b/policies/examples/time_base_test.rego
@@ -9,12 +9,14 @@ no_effective_date := {"msg": "no effective date"}
 
 in_the_past := {"msg": "from the past", "effective_on": "1970-01-01T01:00:00Z"}
 
+y2k := {"msg": "Y2K", "effective_on": "2000-01-01T00:00:00Z"}
+
 test_not_effective_by_default {
 	# The time based filtering happens automatically on the real polices. Replace
 	# those with our example policy.
 	# time_based policy has effective_on far into the future, if you're reading
 	# this then bump it for another 100 years
-	{no_effective_date, in_the_past} == data.main.deny with data.policies as {data.examples.time_based}
+	{no_effective_date, in_the_past, y2k} == data.main.deny with data.policies as {data.examples.time_based}
 		with data.config.policy.non_blocking_checks as []
 }
 
@@ -24,6 +26,16 @@ test_effective_with_time_travel {
 
 	# The time based filtering happens automatically on the real polices. Replace
 	# those with our example policy.
-	{in_the_future, no_effective_date, in_the_past} == data.main.deny with data.policies as {data.examples.time_based}
+	{in_the_future, no_effective_date, in_the_past, y2k} == data.main.deny with data.policies as {data.examples.time_based}
+		with data.config.policy as policy_config
+}
+
+test_y2k_not_failing_before_2000 {
+	# Set the date/time to the future where the example policy becomes effective.
+	policy_config := {"non_blocking_checks": [], "when_ns": time.parse_rfc3339_ns("1999-01-01T00:00:00Z")}
+
+	# The time based filtering happens automatically on the real polices. Replace
+	# those with our example policy.
+	{no_effective_date, in_the_past} == data.main.deny with data.policies as {data.examples.time_based}
 		with data.config.policy as policy_config
 }

--- a/policies/examples/time_based.rego
+++ b/policies/examples/time_based.rego
@@ -1,12 +1,31 @@
 package examples.time_based
 
+# This policy always fails
+# METADATA
+# custom:
+#   effective_on: 2099-05-02T00:00:00Z
+
 # When effective_on is specified, the policy will be ignored until the day/time is reached.
 # Use "effective_on := time.now_ns()", or omit the variable declaration, to make the policy
 # always applicable.
-effective_on := time.parse_rfc3339_ns("2099-05-02T00:00:00Z")
-
-# This policy always fails
-deny[{"msg": msg}] {
+deny[{"msg": msg, "effective_on": rego.metadata.rule().custom.effective_on}] {
 	true
 	msg := "Roads?"
+}
+
+# This policy always fails, but doesn't have effective_on set
+# METADATA
+# custom:
+deny[{"msg": msg}] {
+	true
+	msg := "no effective date"
+}
+
+# This policy always fails, and has a effective_on in the past
+# METADATA
+# custom:
+#   effective_on: 1970-01-01T01:00:00Z
+deny[{"msg": msg, "effective_on": rego.metadata.rule().custom.effective_on}] {
+	true
+	msg := "from the past"
 }

--- a/policies/examples/time_based.rego
+++ b/policies/examples/time_based.rego
@@ -1,4 +1,10 @@
+# METADATA
+# scope: package
+# custom:
+#   effective_on: 2000-01-01T00:00:00Z
 package examples.time_based
+
+import future.keywords.in
 
 # This policy always fails
 # METADATA
@@ -8,9 +14,10 @@ package examples.time_based
 # When effective_on is specified, the policy will be ignored until the day/time is reached.
 # Use "effective_on := time.now_ns()", or omit the variable declaration, to make the policy
 # always applicable.
-deny[{"msg": msg, "effective_on": rego.metadata.rule().custom.effective_on}] {
+deny[{"msg": msg, "effective_on": effective_on}] {
 	true
 	msg := "Roads?"
+	effective_on := when(rego.metadata.chain())
 }
 
 # This policy always fails, but doesn't have effective_on set
@@ -25,7 +32,28 @@ deny[{"msg": msg}] {
 # METADATA
 # custom:
 #   effective_on: 1970-01-01T01:00:00Z
-deny[{"msg": msg, "effective_on": rego.metadata.rule().custom.effective_on}] {
+deny[{"msg": msg, "effective_on": effective_on}] {
 	true
 	msg := "from the past"
+	effective_on := when(rego.metadata.chain())
+}
+
+# This policy fails if today is after 2000-01-01T00:00:00Z but not before it
+# as per the package annotation
+deny[{"msg": msg, "effective_on": effective_on}] {
+	true
+	msg := "Y2K"
+	effective_on := when(rego.metadata.chain())
+}
+
+when(m) = effective_on {
+	precedence := ["rule", "document", "package"]
+	all_effective_on := [e |
+		a := m[_].annotations
+		e = a.custom.effective_on
+		a.scope in precedence
+	]
+
+	# first one found in precedence 
+	effective_on := all_effective_on[0]
 }

--- a/policies/examples/time_based.rego
+++ b/policies/examples/time_based.rego
@@ -4,7 +4,7 @@
 #   effective_on: 2000-01-01T00:00:00Z
 package examples.time_based
 
-import future.keywords.in
+import data.lib.time
 
 # This policy always fails
 # METADATA
@@ -17,7 +17,7 @@ import future.keywords.in
 deny[{"msg": msg, "effective_on": effective_on}] {
 	true
 	msg := "Roads?"
-	effective_on := when(rego.metadata.chain())
+	effective_on := time.when(rego.metadata.chain())
 }
 
 # This policy always fails, but doesn't have effective_on set
@@ -35,7 +35,7 @@ deny[{"msg": msg}] {
 deny[{"msg": msg, "effective_on": effective_on}] {
 	true
 	msg := "from the past"
-	effective_on := when(rego.metadata.chain())
+	effective_on := time.when(rego.metadata.chain())
 }
 
 # This policy fails if today is after 2000-01-01T00:00:00Z but not before it
@@ -43,17 +43,5 @@ deny[{"msg": msg, "effective_on": effective_on}] {
 deny[{"msg": msg, "effective_on": effective_on}] {
 	true
 	msg := "Y2K"
-	effective_on := when(rego.metadata.chain())
-}
-
-when(m) = effective_on {
-	precedence := ["rule", "document", "package"]
-	all_effective_on := [e |
-		a := m[_].annotations
-		e = a.custom.effective_on
-		a.scope in precedence
-	]
-
-	# first one found in precedence 
-	effective_on := all_effective_on[0]
+	effective_on := time.when(rego.metadata.chain())
 }

--- a/policies/lib/time.rego
+++ b/policies/lib/time.rego
@@ -1,0 +1,15 @@
+package lib.time
+
+import future.keywords.in
+
+when(m) = effective_on {
+	precedence := ["rule", "document", "package"]
+	all_effective_on := [e |
+		a := m[_].annotations
+		e = a.custom.effective_on
+		a.scope in precedence
+	]
+
+	# first one found in precedence 
+	effective_on := all_effective_on[0]
+}

--- a/policies/lib/time_test.rego
+++ b/policies/lib/time_test.rego
@@ -1,0 +1,15 @@
+# METADATA
+# custom:
+#   effective_on: 2001-02-03T00:00:00Z
+package lib.time
+
+# METADATA
+# custom:
+#   effective_on: 2004-05-06T00:00:00Z
+test_when_rule_precedence {
+	when(rego.metadata.chain()) == "2004-05-06T00:00:00Z"
+}
+
+test_when_package_precedence {
+	when(rego.metadata.chain()) == "2001-02-03T00:00:00Z"
+}

--- a/policies/main.rego
+++ b/policies/main.rego
@@ -1,27 +1,24 @@
 package main
 
-deny = {denial |
+denials := {denial |
 	not skip(policy)
 	data.policies[policy].deny[_]
 	denial := data.policies[policy].deny[_]
 }
 
-future_deny = {denial |
-	skip_not_in_effect(policy)
-	data.policies[policy].deny[_]
-	denial := data.policies[policy].deny[_]
-}
+deny := {d | denials[d]; not in_future(d)}
+
+future_deny := {d | denials[d]; in_future(d)}
 
 skip(test_name) {
 	data.config.policy.non_blocking_checks[_] == test_name
 }
 
-skip_not_in_effect(policy_name) {
-	# Use the nanosecond epoch defined in the policy if present. Otherwise, use now.
-	when_ns := object.get(data.config.policy, ["when_ns"], time.now_ns())
-	data.policies[policy_name].effective_on > when_ns
-}
+in_future(denial) {
+	# if the denial has effective_on set
+	denial.effective_on
 
-skip(policy_name) {
-	skip_not_in_effect(policy_name)
+	# Use the nanosecond epoch defined in the policy if present. Otherwise, use now.
+	when_ns := object.get(data.config, ["policy", "when_ns"], time.now_ns())
+	time.parse_rfc3339_ns(denial.effective_on) > when_ns
 }

--- a/policies/main.rego
+++ b/policies/main.rego
@@ -18,7 +18,7 @@ in_future(denial) {
 	# if the denial has effective_on set
 	denial.effective_on
 
-	# Use the nanosecond epoch defined in the policy if present. Otherwise, use now.
+	# Use the nanosecond epoch defined in the policy config -- if present. Otherwise, use now.
 	when_ns := object.get(data.config, ["policy", "when_ns"], time.now_ns())
 	time.parse_rfc3339_ns(denial.effective_on) > when_ns
 }


### PR DESCRIPTION
Demonstrates how annotations can be placed in different scopes and how to fetch the effective value of the annotation based on a scoped precedence.

Also includes:

[Different scopes of annotations](https://github.com/hacbs-contract/ec-policies/commit/98af5b0243b07b25f24b0e78c33eb37db4147dd8)

Demonstrates how annotations can be placed in different scopes and how to fetch the effective value of the annotation based on a scoped precedence.
