### PR TITLE
Checks for required annotations in policy files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ amend-fmt: fmt ## Apply default formatting to all rego files then amend the curr
 opa-check: ## Check Rego files with strict mode (https://www.openpolicyagent.org/docs/latest/strict/)
 	@opa check . --strict
 
+conventions-check: ## Check Rego policy files for convention violations
+	@OUT=$$(opa eval --data checks --data policies/lib --input <(opa inspect . -a -f json) 'data.checks.violation[_]' --format raw); \
+	if [[ -n "$${OUT}" ]]; then echo $${OUT}; exit 1; fi
+
 DOCS_BUILD_DIR=./docs
 DOCS_TMP_JSON=$(DOCS_BUILD_DIR)/annotations-data.json
 DOCS_MD=$(DOCS_BUILD_DIR)/index.md
@@ -126,7 +130,7 @@ docs-check: ## Check if docs/index.md is up to date
 	fi
 	@mv $(DOCS_CHECK_TMP) $(DOCS_MD)
 
-ci: quiet-test opa-check fmt-check docs-check ## Runs all checks and tests
+ci: conventions-check quiet-test opa-check fmt-check docs-check ## Runs all checks and tests
 
 #--------------------------------------------------------------------
 

--- a/checks/annotations.rego
+++ b/checks/annotations.rego
@@ -1,0 +1,73 @@
+package checks
+
+import future.keywords.in
+
+# Required annotations on policy rules
+required_annotations := {
+	"title",
+	"description",
+	"custom.short_name",
+	"custom.failure_msg",
+}
+
+# returns Rego files corresponding to policy rules
+policy_rule_files(namespaces) = result {
+	result := {rule |
+		namespaces[n]
+		startswith(n, "data.policies") # look only in the policies namespace
+		rule := {"namespace": n, "files": {file |
+			file := namespaces[n][_]
+			not endswith(file, "_test.rego") # disregard test Rego files
+		}}
+	}
+}
+
+# for annotations defined as:
+# {
+#   "<ann>": "..."
+# }
+# return set with single element "<ann>"
+flat(annotation_name, annotation_definition) = result {
+	is_string(annotation_definition)
+	result := {annotation_name}
+}
+
+# for annotations defined as:
+# {
+#   "<ann1>": {
+#     "<ann2>": "...",
+#     "<ann3>": "..."
+#  }
+# return set with elements "<ann1>.<ann2>" and "<ann1>.<ann3>"
+flat(annotation_name, annotation_definition) = result {
+	is_object(annotation_definition)
+	result := {x |
+		annotation_definition[nested_name]
+		x := concat(".", [annotation_name, nested_name])
+	}
+}
+
+# Validates that the policy rules have all required annotations
+violation[msg] {
+	policy_files := policy_rule_files(input.namespaces)[_]
+
+	some file in policy_files.files
+	annotation := input.annotations[_]
+
+	# just examine Rego files that declare policies
+	annotation.location.file == file
+
+	# gather all annotations in a dotted format (e.g. "custom.short_name")
+	declared_annotations := union({a |
+		annotation.annotations[x]
+		a := flat(x, annotation.annotations[x])
+	})
+
+	# what required annotations are missing
+	missing_annotations := required_annotations - declared_annotations
+
+	# if we have any?
+	count(missing_annotations) > 0
+
+	msg := sprintf("ERROR: Missing annotation(s) %s at %s:%d", [concat(", ", missing_annotations), file, annotation.location.row])
+}

--- a/checks/annotations_test.rego
+++ b/checks/annotations_test.rego
@@ -1,0 +1,56 @@
+package checks
+
+import data.lib
+
+opa_inspect_valid := {
+	"namespaces": {"data.policies.attestation_task_bundle": [
+		"policies/attestation_task_bundle.rego",
+		"policies/attestation_task_bundle_test.rego",
+	]},
+	"annotations": [{
+		"location": {
+			"file": "policies/attestation_task_bundle.rego",
+			"row": 13,
+			"col": 1,
+		},
+		"annotations": {
+			"scope": "rule",
+			"title": "Task bundle was not used or is not defined",
+			"description": "Check for existence of a task bundle. Enforcing this rule will\nfail the contract if the task is not called from a bundle.",
+			"custom": {
+				"failure_msg": "Task '%s' does not contain a bundle reference",
+				"short_name": "disallowed_task_reference",
+			},
+		},
+	}],
+}
+
+test_required_annotations_valid {
+	lib.assert_empty(violation) with input as opa_inspect_valid
+}
+
+opa_inspect_invalid := {
+	"namespaces": {"data.policies.attestation_task_bundle": [
+		"policies/attestation_task_bundle.rego",
+		"policies/attestation_task_bundle_test.rego",
+	]},
+	"annotations": [{
+		"location": {
+			"file": "policies/attestation_task_bundle.rego",
+			"row": 13,
+			"col": 1,
+		},
+		"annotations": {
+			"scope": "rule",
+			"description": "Check for existence of a task bundle. Enforcing this rule will\nfail the contract if the task is not called from a bundle.",
+			"custom": {
+				"flagiure_msg": "Task '%s' does not contain a bundle reference",
+				"short_name": "disallowed_task_reference",
+			},
+		},
+	}],
+}
+
+test_required_annotations_invalid {
+	lib.assert_equal({"ERROR: Missing annotation(s) custom.failure_msg, title at policies/attestation_task_bundle.rego:13"}, violation) with input as opa_inspect_invalid
+}


### PR DESCRIPTION
Adds rules written in Rego to check the output of `opa inspect -a` to
make sure that policies conform to conventions.

First rule added is to check that the required annotations are present.