### PR TITLE
Display future failures as conftest warnings

### DIFF
--- a/checks/annotations.rego
+++ b/checks/annotations.rego
@@ -57,6 +57,9 @@ violation[msg] {
 	# just examine Rego files that declare policies
 	annotation.location.file == file
 
+	# ... and ignore non-rule annotations, e.g. package, document.
+	annotation.annotations.scope == "rule"
+
 	# gather all annotations in a dotted format (e.g. "custom.short_name")
 	declared_annotations := union({a |
 		annotation.annotations[x]

--- a/docs.tmpl
+++ b/docs.tmpl
@@ -21,6 +21,8 @@ Policy Rules
 {{ $p1 := (index (index .path 1) "value") }}
 {{ $p2 := (index (index .path 2) "value") }}
 
+{{/* Skip annotations that are not rule annotations */}}
+{{ if eq .annotations.scope "rule" }}
 {{/* Skip rules that are not under data.policies */}}
 {{ if eq $p1 "policies" }}
 
@@ -51,6 +53,7 @@ The permitted registry prefixes are:
 {{ if coll.Has .annotations.custom "effective_on" }}* Effective from: {{ .annotations.custom.effective_on }}{{ end }}
 
 {{ end }}{{/* if eq $p1 ... */}}
+{{ end }}{{/* if eq .annotations ... */}}
 {{ end }}{{/* range ... */}}
 
 See Also

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ fail the contract if the task is not called from a bundle.
 
 * Path: `data.policies.attestation_task_bundle.warn`
 * Failure message: `Task '%s' does not contain a bundle reference`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/attestation_task_bundle.rego#L13)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/attestation_task_bundle.rego#L16)
 
 #### `[disallowed_task_bundle]` Task bundle was used that was disallowed
 
@@ -34,7 +34,7 @@ fail the contract if the task is not called using a valid bundle image.
 
 * Path: `data.policies.attestation_task_bundle.warn`
 * Failure message: `Task '%s' has disallowed bundle image '%s'`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/attestation_task_bundle.rego#L32)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/attestation_task_bundle.rego#L35)
 
 ### Attestation Type Rules
 
@@ -46,7 +46,7 @@ attestation type. Currently there is only one attestation type supported,
 
 * Path: `data.policies.attestation_type.deny`
 * Failure message: `Unknown attestation type '%s'`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/attestation_type.rego#L18)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/attestation_type.rego#L21)
 
 ### Not Useful Rules
 
@@ -57,7 +57,7 @@ This rule is for demonstration and test purposes and should be deleted soon.
 
 * Path: `data.policies.not_useful.deny`
 * Failure message: `It just feels like a bad day to do a release`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/not_useful.rego#L14)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/not_useful.rego#L17)
 
 ### Step Image Registries Rules
 
@@ -81,7 +81,7 @@ registry.redhat.io/openshift-pipelines
 
 * Path: `data.policies.step_image_registries.deny`
 * Failure message: `Step %d in task '%s' has disallowed image ref '%s'`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/step_image_registries.rego#L23)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/step_image_registries.rego#L26)
 
 ### Test Rules
 
@@ -93,7 +93,7 @@ test result data.
 
 * Path: `data.policies.test.deny`
 * Failure message: `No test data found`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/test.rego#L15)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/test.rego#L18)
 
 #### `[test_results_missing]` Test data is missing the results key
 
@@ -102,7 +102,7 @@ one of the HACBS_TEST_OUTPUT task results this key was not present.
 
 * Path: `data.policies.test.deny`
 * Failure message: `Found tests without results`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/test.rego#L29)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/test.rego#L32)
 
 #### `[test_result_failures]` Some tests did not pass
 
@@ -113,7 +113,7 @@ of the failing tests.
 
 * Path: `data.policies.test.deny`
 * Failure message: `The following tests did not complete successfully: %s`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/test.rego#L46)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policies/test.rego#L49)
 
 See Also
 --------

--- a/policies/attestation_task_bundle.rego
+++ b/policies/attestation_task_bundle.rego
@@ -17,7 +17,7 @@ warn[result] {
 	task := lib.tasks_from_pipelinerun[_]
 	name := task.name
 	not task.ref.bundle
-	result := lib.result_helper(rego.metadata.rule(), [name])
+	result := lib.result_helper(rego.metadata.chain(), [name])
 }
 
 # METADATA
@@ -37,5 +37,5 @@ warn[result] {
 	name := task.name
 	bundle := split(task.ref.bundle, ":")
 	not lib.item_in_list(bundle[0], rego.metadata.rule().custom.allowed_bundles)
-	result := lib.result_helper(rego.metadata.rule(), [name, bundle[0]])
+	result := lib.result_helper(rego.metadata.chain(), [name, bundle[0]])
 }

--- a/policies/attestation_task_bundle.rego
+++ b/policies/attestation_task_bundle.rego
@@ -1,3 +1,6 @@
+# METADATA
+# custom:
+#   effective_on: 2022-01-01T00:00:00Z
 package policies.attestation_task_bundle
 
 import data.lib

--- a/policies/attestation_task_bundle_test.rego
+++ b/policies/attestation_task_bundle_test.rego
@@ -17,7 +17,11 @@ test_bundle_not_exists {
 	})
 
 	expected_msg := "Task 'my-task' does not contain a bundle reference"
-	lib.assert_equal(warn, {{"code": "disallowed_task_reference", "msg": expected_msg}}) with input.attestations as d
+	lib.assert_equal(warn, {{
+		"code": "disallowed_task_reference",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as d
 }
 
 test_bundle_not_exists_emtpy_string {
@@ -29,7 +33,11 @@ test_bundle_not_exists_emtpy_string {
 	})
 
 	expected_msg := sprintf("Task '%s' has disallowed bundle image '%s'", [name, image])
-	lib.assert_equal(warn, {{"code": "disallowed_task_bundle", "msg": expected_msg}}) with input.attestations as d
+	lib.assert_equal(warn, {{
+		"code": "disallowed_task_bundle",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as d
 }
 
 test_bundle_reference_not_valid {
@@ -45,7 +53,11 @@ test_bundle_reference_not_valid {
 	})
 
 	expected_msg := sprintf("Task '%s' has disallowed bundle image '%s'", [name, prefix[0]])
-	lib.assert_equal(warn, {{"code": "disallowed_task_bundle", "msg": expected_msg}}) with input.attestations as d
+	lib.assert_equal(warn, {{
+		"code": "disallowed_task_bundle",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as d
 }
 
 test_bundle_reference_valid {
@@ -61,5 +73,9 @@ test_bundle_reference_valid {
 	})
 
 	expected_msg := sprintf("Task '%s' has disallowed bundle image '%s'", [name, prefix[0]])
-	not lib.assert_equal(warn, {{"code": "disallowed_task_bundle", "msg": expected_msg}}) with input.attestations as d
+	not lib.assert_equal(warn, {{
+		"code": "disallowed_task_bundle",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as d
 }

--- a/policies/attestation_type.rego
+++ b/policies/attestation_type.rego
@@ -1,3 +1,6 @@
+# METADATA
+# custom:
+#   effective_on: 2022-01-01T00:00:00Z
 package policies.attestation_type
 
 import data.lib

--- a/policies/attestation_type.rego
+++ b/policies/attestation_type.rego
@@ -22,7 +22,7 @@ deny[result] {
 	att := lib.pipelinerun_attestations[_]
 	att_type := att._type
 	not known_att_type(att_type)
-	result := lib.result_helper(rego.metadata.rule(), [att_type])
+	result := lib.result_helper(rego.metadata.chain(), [att_type])
 }
 
 known_att_type(att_type) {

--- a/policies/attestation_type_test.rego
+++ b/policies/attestation_type_test.rego
@@ -22,5 +22,9 @@ test_allow_when_permitted {
 
 test_deny_when_not_permitted {
 	expected_msg := sprintf("Unknown attestation type '%s'", [bad_type])
-	lib.assert_equal(deny, {{"code": "unknown_att_type", "msg": expected_msg}}) with input.attestations as mock_data(bad_type)
+	lib.assert_equal(deny, {{
+		"code": "unknown_att_type",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_data(bad_type)
 }

--- a/policies/lib/string_utils.rego
+++ b/policies/lib/string_utils.rego
@@ -1,5 +1,7 @@
 package lib
 
+import data.lib.time
+
 import future.keywords.in
 
 item_in_list(item, list_or_set) {
@@ -21,9 +23,14 @@ quoted_values_string(value_list) = result {
 	result := concat(", ", quoted_list)
 }
 
-result_helper(rule_metadata, failure_sprintf_params) = result {
+result_helper(chain, failure_sprintf_params) = result {
+	# The first entry in the chain always points to the active rule, even if it has
+	# no declared annotations (in which case the annotations member is not present).
+	# Thus, results_helper assumes every rule defines annotations.
+	rule_annotations := chain[0].annotations
 	result := {
-		"code": rule_metadata.custom.short_name,
-		"msg": sprintf(rule_metadata.custom.failure_msg, failure_sprintf_params),
+		"code": rule_annotations.custom.short_name,
+		"msg": sprintf(rule_annotations.custom.failure_msg, failure_sprintf_params),
+		"effective_on": time.when(chain),
 	}
 }

--- a/policies/main.rego
+++ b/policies/main.rego
@@ -8,7 +8,7 @@ denials := {denial |
 
 deny := {d | denials[d]; not in_future(d)}
 
-future_deny := {d | denials[d]; in_future(d)}
+warn := {d | denials[d]; in_future(d)}
 
 skip(test_name) {
 	data.config.policy.non_blocking_checks[_] == test_name

--- a/policies/main_test.rego
+++ b/policies/main_test.rego
@@ -22,7 +22,18 @@ test_failing_without_skipping {
 	# Let's make sure that the contract remains the same by checking what `deny` is set to
 	# this makes this test a bit more fragile, but the assertion is better as we know that
 	# the output hasn't changed it's shape
-	lib.assert_equal(deny, {{"code": "bad_day", "msg": "It just feels like a bad day to do a release"}, {"code": "test_data_missing", "msg": "No test data found"}}) with data.config.policy as nonblocking_only(set())
+	lib.assert_equal(deny, {
+		{
+			"code": "bad_day",
+			"msg": "It just feels like a bad day to do a release",
+			"effective_on": "2022-01-01T00:00:00Z",
+		},
+		{
+			"code": "test_data_missing",
+			"msg": "No test data found",
+			"effective_on": "2022-01-01T00:00:00Z",
+		},
+	}) with data.config.policy as nonblocking_only(set())
 }
 
 test_succeeding_when_skipping_all {
@@ -30,7 +41,11 @@ test_succeeding_when_skipping_all {
 }
 
 test_test_can_be_skipped {
-	lib.assert_equal(deny, {{"code": "test_data_missing", "msg": "No test data found"}}) with data.config.policy as nonblocking_except({"test"})
+	lib.assert_equal(deny, {{
+		"code": "test_data_missing",
+		"msg": "No test data found",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with data.config.policy as nonblocking_except({"test"})
 }
 
 test_test_succeeds {
@@ -38,7 +53,11 @@ test_test_succeeds {
 }
 
 test_test_fails {
-	lib.assert_equal(deny, {{"code": "test_result_failures", "msg": "The following tests did not complete successfully: test1"}}) with input.attestations as [lib.att_mock_helper({"result": "FAILURE"}, "test1")] with data.config.policy as nonblocking_except({"test"})
+	lib.assert_equal(deny, {{
+		"code": "test_result_failures",
+		"msg": "The following tests did not complete successfully: test1",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as [lib.att_mock_helper({"result": "FAILURE"}, "test1")] with data.config.policy as nonblocking_except({"test"})
 }
 
 test_policy_ignored_when_not_yet_effective {

--- a/policies/main_test.rego
+++ b/policies/main_test.rego
@@ -65,7 +65,7 @@ test_policy_ignored_when_not_yet_effective {
 	set() == deny with denials as {future_denial}
 		with data.config.policy as nonblocking_except({"test", "not_useful"})
 
-	{future_denial} == future_deny with denials as {future_denial}
+	{future_denial} == warn with denials as {future_denial}
 		with data.config.policy as nonblocking_except({"test", "not_useful"})
 }
 
@@ -85,7 +85,7 @@ test_policy_not_ignored_when_effective_with_time_travel {
 	{expected_error} == deny with denials as {expected_error}
 		with data.config.policy as policy_config
 
-	set() == future_deny with denials as {expected_error}
+	set() == warn with denials as {expected_error}
 		with data.config.policy as policy_config
 }
 
@@ -105,7 +105,7 @@ test_future_denial {
 	set() == deny with denials as {expected_error}
 		with data.config as {}
 
-	{expected_error} == future_deny with denials as {expected_error}
+	{expected_error} == warn with denials as {expected_error}
 		with data.config as {}
 }
 

--- a/policies/not_useful.rego
+++ b/policies/not_useful.rego
@@ -16,5 +16,5 @@ import data.lib
 #
 deny[result] {
 	true
-	result := lib.result_helper(rego.metadata.rule(), [])
+	result := lib.result_helper(rego.metadata.chain(), [])
 }

--- a/policies/not_useful.rego
+++ b/policies/not_useful.rego
@@ -1,3 +1,6 @@
+# METADATA
+# custom:
+#   effective_on: 2022-01-01T00:00:00Z
 package policies.not_useful
 
 import data.lib

--- a/policies/not_useful_test.rego
+++ b/policies/not_useful_test.rego
@@ -1,3 +1,6 @@
+# METADATA
+# custom:
+#   effective_on: 2022-01-01T00:00:00Z
 package policies.not_useful
 
 import data.lib

--- a/policies/not_useful_test.rego
+++ b/policies/not_useful_test.rego
@@ -6,5 +6,9 @@ package policies.not_useful
 import data.lib
 
 test_not_useful {
-	lib.assert_equal(deny, {{"code": "bad_day", "msg": "It just feels like a bad day to do a release"}})
+	lib.assert_equal(deny, {{
+		"code": "bad_day",
+		"msg": "It just feels like a bad day to do a release",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}})
 }

--- a/policies/step_image_registries.rego
+++ b/policies/step_image_registries.rego
@@ -29,7 +29,7 @@ deny[result] {
 	step := task.steps[step_index]
 	image_ref := step.environment.image
 	not image_ref_permitted(image_ref, rego.metadata.rule().custom.allowed_registry_prefixes)
-	result := lib.result_helper(rego.metadata.rule(), [step_index, task.name, image_ref])
+	result := lib.result_helper(rego.metadata.chain(), [step_index, task.name, image_ref])
 }
 
 image_ref_permitted(image_ref, allowed_prefixes) {

--- a/policies/step_image_registries.rego
+++ b/policies/step_image_registries.rego
@@ -1,3 +1,6 @@
+# METADATA
+# custom:
+#   effective_on: 2022-01-01T00:00:00Z
 package policies.step_image_registries
 
 import data.lib

--- a/policies/step_image_registries_test.rego
+++ b/policies/step_image_registries_test.rego
@@ -19,5 +19,9 @@ test_image_registry_valid {
 
 test_attestation_type_invalid {
 	expected_msg := sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image])
-	lib.assert_equal(deny, {{"code": "disallowed_task_step_image", "msg": expected_msg}}) with input.attestations as mock_data(bad_image)
+	lib.assert_equal(deny, {{
+		"code": "disallowed_task_step_image",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_data(bad_image)
 }

--- a/policies/test.rego
+++ b/policies/test.rego
@@ -17,7 +17,7 @@ import data.lib
 #
 deny[result] {
 	count(lib.results_from_tests) == 0
-	result := lib.result_helper(rego.metadata.rule(), [])
+	result := lib.result_helper(rego.metadata.chain(), [])
 }
 
 # METADATA
@@ -32,7 +32,7 @@ deny[result] {
 deny[result] {
 	with_results := [result | result := lib.results_from_tests[_].result]
 	count(with_results) != count(lib.results_from_tests)
-	result := lib.result_helper(rego.metadata.rule(), [])
+	result := lib.result_helper(rego.metadata.chain(), [])
 }
 
 # METADATA
@@ -67,7 +67,7 @@ deny[result] {
 
 	short_failed_blocking := [f | f := split(failed_blocking[_], ":")[1]]
 	result := lib.result_helper(
-		rego.metadata.rule(),
+		rego.metadata.chain(),
 		[concat(", ", short_failed_blocking)],
 	)
 }

--- a/policies/test.rego
+++ b/policies/test.rego
@@ -1,3 +1,6 @@
+# METADATA
+# custom:
+#   effective_on: 2022-01-01T00:00:00Z
 package policies.test
 
 import data.lib

--- a/policies/test_test.rego
+++ b/policies/test_test.rego
@@ -10,20 +10,35 @@ mock_empty_data := [json.patch(lib.att_mock_helper({}, "task1"), [{
 }])]
 
 test_needs_non_empty_data {
-	lib.assert_equal(deny, {{"code": "test_data_missing", "msg": "No test data found"}}) with input.attestations as mock_empty_data
+	lib.assert_equal(deny, {{
+		"code": "test_data_missing",
+		"msg": "No test data found",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_empty_data
 }
 
 # There is a test result, but the data inside it doesn't include the "result" key
 mock_without_results_data := [lib.att_mock_helper({"rezult": "SUCCESS"}, "task1")]
 
 test_needs_tests_with_results {
-	lib.assert_equal(deny, {{"code": "test_results_missing", "msg": "Found tests without results"}}) with input.attestations as mock_without_results_data
+	lib.assert_equal(deny, {{
+		"code": "test_results_missing",
+		"msg": "Found tests without results",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_without_results_data
 }
 
-mock_without_results_data_mixed := [lib.att_mock_helper({"result": "SUCCESS"}, "task1"), lib.att_mock_helper({"rezult": "SUCCESS"}, "task2")]
+mock_without_results_data_mixed := [
+	lib.att_mock_helper({"result": "SUCCESS"}, "task1"),
+	lib.att_mock_helper({"rezult": "SUCCESS"}, "task2"),
+]
 
 test_needs_tests_with_results_mixed {
-	lib.assert_equal(deny, {{"code": "test_results_missing", "msg": "Found tests without results"}}) with input.attestations as mock_without_results_data_mixed
+	lib.assert_equal(deny, {{
+		"code": "test_results_missing",
+		"msg": "Found tests without results",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_without_results_data_mixed
 }
 
 mock_a_passing_test := [lib.att_mock_helper({"result": "SUCCESS"}, "task1")]
@@ -36,21 +51,33 @@ test_success_data {
 mock_a_failing_test := [lib.att_mock_helper({"result": "FAILURE"}, "failed_1")]
 
 test_failure_data {
-	lib.assert_equal(deny, {{"code": "test_result_failures", "msg": "The following tests did not complete successfully: failed_1"}}) with input.attestations as mock_a_failing_test
+	lib.assert_equal(deny, {{
+		"code": "test_result_failures",
+		"msg": "The following tests did not complete successfully: failed_1",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_a_failing_test
 		with data.config.policy as {"non_blocking_checks": []}
 }
 
 mock_an_errored_test := [lib.att_mock_helper({"result": "ERROR"}, "errored_1")]
 
 test_error_data {
-	lib.assert_equal(deny, {{"code": "test_result_failures", "msg": "The following tests did not complete successfully: errored_1"}}) with input.attestations as mock_an_errored_test
+	lib.assert_equal(deny, {{
+		"code": "test_result_failures",
+		"msg": "The following tests did not complete successfully: errored_1",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_an_errored_test
 		with data.config.policy as {"non_blocking_checks": []}
 }
 
 mock_mixed_data := array.concat(mock_a_failing_test, mock_an_errored_test)
 
 test_mix_data {
-	lib.assert_equal(deny, {{"code": "test_result_failures", "msg": "The following tests did not complete successfully: errored_1, failed_1"}}) with input.attestations as mock_mixed_data
+	lib.assert_equal(deny, {{
+		"code": "test_result_failures",
+		"msg": "The following tests did not complete successfully: errored_1, failed_1",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_mixed_data
 		with data.config.policy as {"non_blocking_checks": []}
 }
 
@@ -58,6 +85,10 @@ test_can_skip_by_name {
 	lib.assert_empty(deny) with input.attestations as mock_mixed_data
 		with data.config.policy as {"non_blocking_checks": ["test:errored_1", "test:failed_1"]}
 
-	lib.assert_equal(deny, {{"code": "test_result_failures", "msg": "The following tests did not complete successfully: errored_1"}}) with input.attestations as mock_mixed_data
+	lib.assert_equal(deny, {{
+		"code": "test_result_failures",
+		"msg": "The following tests did not complete successfully: errored_1",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as mock_mixed_data
 		with data.config.policy as {"non_blocking_checks": ["test:failed_1"]}
 }


### PR DESCRIPTION
Issue: [HACBS-520](https://issues.redhat.com/browse/HACBS-520)

## Add default `effective_on` date to all rules

Every existing rule has a default `effective_on` date set to the beginning
of the year 2022. This is an arbitrary date to capture rules that have
already been effective before the introduction of time-based rules.

As per previous design decision, every policy rule should have an
explicit `effective_on` date to better assist the policy rule authors when
introducing a new policy rule.

## Expose `effective_on` in rules result

In addition to the error message, `msg`, and `metadata.code`, a rule
result will also include `metadata.effective_on`. This is meant to
assist users in determining when a blocking issue has been introduced.

## Rename `future_deny` to warn

So it is automatically reported as warnings by conftest.

Since `metadata.effective_on` is already present in the rules result,
this also aids users in determining when a warning will be treated as a
hard failure.