### PR TITLE
Add a 'task must be present' rule for pipelines

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -15,15 +15,33 @@ and are described here.</p>+++
 
 === Basic Rules
 
-==== `[unexpected_kind]` Check the kind is "Pipeline"
+==== `[unexpected_kind]` Input data has unexpected kind
 
-A sanity check to confirm the input data has the expected kind.
+A sanity check to confirm the input data has the kind "Pipeline"
 
 ++++
 <ul>
 <li>Path: <code>data.policy.pipeline.basic.deny</code></li>
 <li>Failure message: <code>Unexpected kind '%s'</code></li>
 <li><a href="https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/basic.rego#L19">Source</a></li>
+</ul>
+++++
+
+=== Required Tasks Rules
+
+==== `[required_tasks]` Pipeline does not include all required check tasks
+
+Every build pipeline is expected to contain a set of checks and tests that
+are required by the Enterprise Contract. This rule confirms that the pipeline
+definition includes all the expected tasks.
+
+The matching is done using the taskRef name rather than the pipeline task name.
+
+++++
+<ul>
+<li>Path: <code>data.policy.pipeline.required_tasks.deny</code></li>
+<li>Failure message: <code>Required tasks %s were not found in the pipeline's task list</code></li>
+<li><a href="https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/required_tasks.rego#L31">Source</a></li>
 </ul>
 ++++
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,13 +18,27 @@ Pipeline Policy
 
 ### Basic Rules
 
-#### `[unexpected_kind]` Check the kind is "Pipeline"
+#### `[unexpected_kind]` Input data has unexpected kind
 
-A sanity check to confirm the input data has the expected kind.
+A sanity check to confirm the input data has the kind "Pipeline"
 
 * Path: `data.policy.pipeline.basic.deny`
 * Failure message: `Unexpected kind '%s'`
 * [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/basic.rego#L19)
+
+### Required Tasks Rules
+
+#### `[required_tasks]` Pipeline does not include all required check tasks
+
+Every build pipeline is expected to contain a set of checks and tests that
+are required by the Enterprise Contract. This rule confirms that the pipeline
+definition includes all the expected tasks.
+
+The matching is done using the taskRef name rather than the pipeline task name.
+
+* Path: `data.policy.pipeline.required_tasks.deny`
+* Failure message: `Required tasks %s were not found in the pipeline's task list`
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/required_tasks.rego#L31)
 
 Release Policy
 ---------------

--- a/policy/pipeline/basic.rego
+++ b/policy/pipeline/basic.rego
@@ -9,9 +9,9 @@ expected_kind := "Pipeline"
 # Fixme: It doesn't fail if the kind key is entirely missing..
 
 # METADATA
-# title: Check the kind is "Pipeline"
+# title: Input data has unexpected kind
 # description: |-
-#   A sanity check to confirm the input data has the expected kind.
+#   A sanity check to confirm the input data has the kind "Pipeline"
 # custom:
 #   short_name: unexpected_kind
 #   failure_msg: Unexpected kind '%s'

--- a/policy/pipeline/main_test.rego
+++ b/policy/pipeline/main_test.rego
@@ -4,6 +4,7 @@ import data.lib
 
 test_passing {
 	lib.assert_empty(deny) with input.kind as "Pipeline"
+		with data.config.policy.non_blocking_checks as ["required_tasks"]
 }
 
 test_failing {
@@ -12,6 +13,7 @@ test_failing {
 		"msg": "Unexpected kind 'Zipline'",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.kind as "Zipline"
+		with data.config.policy.non_blocking_checks as ["required_tasks"]
 }
 
 test_in_future {

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -1,0 +1,49 @@
+package policy.pipeline.required_tasks
+
+import data.lib
+
+# Note: I created the required_task_refs list by plucking out the testing
+# related tasks from the build pipeline definitions in the build-definitions
+# repo. Run `kustomize build pipelines/hacbs` in that repo to see the latest
+# definitions.
+
+# METADATA
+# title: Pipeline does not include all required check tasks
+# description: |-
+#   Every build pipeline is expected to contain a set of checks and tests that
+#   are required by the Enterprise Contract. This rule confirms that the pipeline
+#   definition includes all the expected tasks.
+#
+#   The matching is done using the taskRef name rather than the pipeline task name.
+#
+# custom:
+#   short_name: required_tasks
+#   failure_msg: Required tasks %s were not found in the pipeline's task list
+#   required_task_refs:
+#   - clamav-scan
+#   - conftest-clair
+#   - get-clair-scan
+#   - sanity-inspect-image
+#   - sanity-label-check
+#   - sast-go
+#   - sast-java-sec-check
+#
+deny[result] {
+	# Find the data in the annotations
+	required_list := rego.metadata.rule().custom.required_task_refs
+
+	# Convert it to a set
+	required := {t | t := required_list[_]}
+
+	# The set of tasks that we did find
+	found := {t | t := input.spec.tasks[_].taskRef.name}
+
+	# The set difference is the set of missing tasks
+	missing := required - found
+
+	# Trigger this rule if any are missing
+	count(missing) != 0
+
+	# Pass back the usual result map
+	result := lib.result_helper(rego.metadata.chain(), [lib.quoted_values_string(missing)])
+}

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -1,0 +1,51 @@
+package policy.pipeline.required_tasks
+
+import data.lib
+
+mock_taskref_data(task_ref_names) = d {
+	d := [x |
+		name := task_ref_names[_]
+		x := {"taskRef": {"name": name}}
+	]
+}
+
+all_required_task_refs := [
+	"clamav-scan",
+	"conftest-clair",
+	"get-clair-scan",
+	"sanity-inspect-image",
+	"sanity-label-check",
+	"sast-go",
+	"sast-java-sec-check",
+]
+
+all_bar_two := array.slice(all_required_task_refs, 2, count(all_required_task_refs))
+
+test_passing {
+	lib.assert_empty(deny) with input.spec.tasks as mock_taskref_data(all_required_task_refs)
+		with input.kind as "Pipeline"
+}
+
+test_failing {
+	lib.assert_equal(deny, {{
+		"code": "required_tasks",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Required tasks 'clamav-scan', 'conftest-clair' were not found in the pipeline's task list",
+	}}) with input.kind as "Pipeline" with input.spec.tasks as mock_taskref_data(all_bar_two)
+}
+
+test_edge_cases {
+	failure_msg_end := "not found in the pipeline's task list"
+
+	# No tasks at all
+	endswith(deny[_].msg, failure_msg_end) with input.kind as "Pipeline"
+
+	# Task list is empty
+	endswith(deny[_].msg, failure_msg_end) with input.kind as "Pipeline" with input.spec.tasks as []
+
+	# A task without a taskRef
+	endswith(deny[_].msg, failure_msg_end) with input.kind as "Pipeline" with input.spec.tasks as [{"foo": "bar"}]
+
+	# A task without a taskRef name
+	endswith(deny[_].msg, failure_msg_end) with input.kind as "Pipeline" with input.spec.tasks as [{"taskRef": {"foo": "bar"}}]
+}


### PR DESCRIPTION
This was added quickly as a potential demo for how pipeline
validation could work.

I'm not sure if matching the taskRef name is a secure approach in
the long term, but it might be a good starting point.