### PR TITLE
Refactor annotations data handling for docs

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -37,11 +37,23 @@ definition includes all the expected tasks.
 
 The matching is done using the taskRef name rather than the pipeline task name.
 
+The required task refs are:
+
+----
+clamav-scan
+conftest-clair
+get-clair-scan
+sanity-inspect-image
+sanity-label-check
+sast-go
+sast-java-sec-check
+----
+
 ++++
 <ul>
 <li>Path: <code>data.policy.pipeline.required_tasks.deny</code></li>
 <li>Failure message: <code>Required tasks %s were not found in the pipeline's task list</code></li>
-<li><a href="https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/required_tasks.rego#L31">Source</a></li>
+<li><a href="https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/required_tasks.rego#L32">Source</a></li>
 </ul>
 ++++
 
@@ -115,7 +127,7 @@ Enterprise Contract has a list of allowed registry prefixes. Each step in each
 each TaskRun must run on a container image with a url that matches one of the
 prefixes in the list.
 
-The permitted registry prefixes are:
+The allowed registry prefixes are:
 
 ----
 quay.io/redhat-appstudio/
@@ -127,7 +139,7 @@ registry.redhat.io/
 <ul>
 <li>Path: <code>data.policy.release.step_image_registries.deny</code></li>
 <li>Failure message: <code>Step %d in task '%s' has disallowed image ref '%s'</code></li>
-<li><a href="https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/step_image_registries.rego#L19">Source</a></li>
+<li><a href="https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/step_image_registries.rego#L20">Source</a></li>
 </ul>
 ++++
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,21 @@ definition includes all the expected tasks.
 
 The matching is done using the taskRef name rather than the pipeline task name.
 
+The required task refs are:
+
+```
+clamav-scan
+conftest-clair
+get-clair-scan
+sanity-inspect-image
+sanity-label-check
+sast-go
+sast-java-sec-check
+```
+
 * Path: `data.policy.pipeline.required_tasks.deny`
 * Failure message: `Required tasks %s were not found in the pipeline's task list`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/required_tasks.rego#L31)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policy/pipeline/required_tasks.rego#L32)
 
 Release Policy
 ---------------
@@ -95,7 +107,7 @@ Enterprise Contract has a list of allowed registry prefixes. Each step in each
 each TaskRun must run on a container image with a url that matches one of the
 prefixes in the list.
 
-The permitted registry prefixes are:
+The allowed registry prefixes are:
 
 ```
 quay.io/redhat-appstudio/
@@ -105,7 +117,7 @@ registry.redhat.io/
 
 * Path: `data.policy.release.step_image_registries.deny`
 * Failure message: `Step %d in task '%s' has disallowed image ref '%s'`
-* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/step_image_registries.rego#L19)
+* [Source](https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/step_image_registries.rego#L20)
 
 ### Test Rules
 

--- a/docsrc/index.adoc.tmpl
+++ b/docsrc/index.adoc.tmpl
@@ -41,15 +41,18 @@
 
 {{.annotations.description}}
 
-{{/* Special handling */}}
-{{ if has .annotations.custom "allowed_registry_prefixes" }}
-The permitted registry prefixes are:
+{{/* Show rule data if there is any */}}
+{{ if has .annotations.custom "rule_data" }}
+{{ range $key, $values := .annotations.custom.rule_data }}
+{{/* Assume the key name is descriptive enough for this sentence to make sense */}}
+The {{ $key | strings.ReplaceAll "_" " " }} are:
 
 ----
-{{- range .annotations.custom.allowed_registry_prefixes }}
+{{- range $values }}
 {{ . }}{{ end }}
 ----
 
+{{ end }}
 {{ end }}
 
 {{/* Use html to avoid annoying extra p elements inside the list items */}}

--- a/docsrc/index.md.tmpl
+++ b/docsrc/index.md.tmpl
@@ -44,15 +44,18 @@ About
 
 {{.annotations.description}}
 
-{{/* Special handling */}}
-{{ if has .annotations.custom "allowed_registry_prefixes" }}
-The permitted registry prefixes are:
+{{/* Show rule data if there is any */}}
+{{ if has .annotations.custom "rule_data" }}
+{{ range $key, $values := .annotations.custom.rule_data }}
+{{/* Assume the key name is descriptive enough for this sentence to make sense */}}
+The {{ $key | strings.ReplaceAll "_" " " }} are:
 
 ```
-{{- range .annotations.custom.allowed_registry_prefixes }}
+{{- range $values }}
 {{ . }}{{ end }}
 ```
 
+{{ end }}
 {{ end }}
 
 * Path: `{{ range $i, $v := .path }}{{ if ne 0 $i }}.{{ end }}{{ $v.value }}{{ end }}`

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -19,18 +19,19 @@ import data.lib
 # custom:
 #   short_name: required_tasks
 #   failure_msg: Required tasks %s were not found in the pipeline's task list
-#   required_task_refs:
-#   - clamav-scan
-#   - conftest-clair
-#   - get-clair-scan
-#   - sanity-inspect-image
-#   - sanity-label-check
-#   - sast-go
-#   - sast-java-sec-check
+#   rule_data:
+#     required_task_refs:
+#     - clamav-scan
+#     - conftest-clair
+#     - get-clair-scan
+#     - sanity-inspect-image
+#     - sanity-label-check
+#     - sast-go
+#     - sast-java-sec-check
 #
 deny[result] {
 	# Find the data in the annotations
-	required_list := rego.metadata.rule().custom.required_task_refs
+	required_list := rego.metadata.rule().custom.rule_data.required_task_refs
 
 	# Convert it to a set
 	required := {t | t := required_list[_]}

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -11,17 +11,18 @@ import data.lib
 # custom:
 #   short_name: disallowed_task_step_image
 #   failure_msg: Step %d in task '%s' has disallowed image ref '%s'
-#   allowed_registry_prefixes:
-#   - quay.io/redhat-appstudio/
-#   - registry.access.redhat.com/
-#   - registry.redhat.io/
+#   rule_data:
+#     allowed_registry_prefixes:
+#     - quay.io/redhat-appstudio/
+#     - registry.access.redhat.com/
+#     - registry.redhat.io/
 #
 deny[result] {
 	att := lib.pipelinerun_attestations[_]
 	task := att.predicate.buildConfig.tasks[_]
 	step := task.steps[step_index]
 	image_ref := step.environment.image
-	not image_ref_permitted(image_ref, rego.metadata.rule().custom.allowed_registry_prefixes)
+	not image_ref_permitted(image_ref, rego.metadata.rule().custom.rule_data.allowed_registry_prefixes)
 	result := lib.result_helper(rego.metadata.chain(), [step_index, task.name, image_ref])
 }
 


### PR DESCRIPTION
Make it so we don't need custom content in the docs templates each
time we use annotations data in a rule, which causes the required
task refs from the new pipeline rule to appear in the docs where
they didn't before.