### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,7 @@ you can use this to show what lines of code are not covered:
 
     make coverage
 
-Getting started for policy authors
-----------------------------------
-
-See the [Policy Authoring](POLICY_AUTHORING.md) documentation for guidance on
-contributing to the definition of policy rules.
-
-
-Running the policies against real data
---------------------------------------
+### Running policies against real pipline run image build attestations
 
 Fetch an image attestation from a registry:
 
@@ -104,20 +96,40 @@ Create a dummy policy config file:
     make dummy-config
     cat data/config.json # to look at it
 
-Now run the policies against the attestation data:
+Then to verify the build using the defined policies:
 
     make check-release
 
-You can do something similar for pipeline policies, for example:
+### Running policies against real pipeline definitions
+
+For example to fetch a pipeline definition from your local cluster:
 
     make fetch-pipeline
+    make fetch-pipeline PIPELINE=<some-pipeline-name>
+    more input/input.json # to look at it
+
+For a realistic HACBS pipeline definition that does't require cluster access,
+if you you have the [build-definitions][builddefs] repo checked out nearby you
+can do something like this:
+
+    ( cd ../build-definitions && kustomize build pipelines/hacbs | yq 'select(document_index == 2)' -o json ) > input/input.json
+
+Then to verify the pipeline definition using the defined policies:
+
     make check-pipeline
+
+
+Getting started for policy authors
+----------------------------------
+
+See the [Policy Authoring](POLICY_AUTHORING.md) documentation for guidance on
+contributing to the definition of policy rules.
 
 
 See also
 --------
 
-* [Policy rule documentation][hacbsdocs].
+* [Policy rule documentation][hacbsdocs]
 * ["Verify Enterprise Contract" task definition][taskdef]
 * [github.com/hacbs-contract][contract]
 * [github.com/redhat-appstudio][appstudio]
@@ -132,3 +144,4 @@ See also
 [taskdef]: https://github.com/redhat-appstudio/build-definitions/blob/main/tasks/verify-enterprise-contract.yaml
 [contract]: https://github.com/hacbs-contract
 [appstudio]: https://github.com/redhat-appstudio
+[builddefs]: https://github.com/redhat-appstudio/build-definitions


### PR DESCRIPTION
Add more detail about how to fetch pipeline definition data for
hacking. Also move the "running with real data" sections
down a level since they don't seem to warrant being level 2
headings.