### PR TITLE
Add appstudio-tasks to permitted task bundles list

### DIFF
--- a/antora-docs/modules/ROOT/pages/index.adoc
+++ b/antora-docs/modules/ROOT/pages/index.adoc
@@ -77,7 +77,7 @@ fail the contract if the task is not called from a bundle.
 
 * Path: `data.policy.release.attestation_task_bundle.warn`
 * Failure message: `Task '%s' does not contain a bundle reference`
-* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/attestation_task_bundle.rego#L13[Source]
+* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/attestation_task_bundle.rego#L14[Source]
 
 [#disallowed_task_bundle]
 ==== link:#disallowed_task_bundle[`disallowed_task_bundle`] Task bundle was used that was disallowed
@@ -85,9 +85,17 @@ fail the contract if the task is not called from a bundle.
 Check for existence of a valid task bundle. Enforcing this rule will
 fail the contract if the task is not called using a valid bundle image.
 
+The allowed bundles are:
+
+----
+quay.io/redhat-appstudio/build-templates-bundle
+quay.io/redhat-appstudio/hacbs-templates-bundle
+quay.io/redhat-appstudio/appstudio-tasks
+----
+
 * Path: `data.policy.release.attestation_task_bundle.warn`
 * Failure message: `Task '%s' has disallowed bundle image '%s'`
-* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/attestation_task_bundle.rego#L32[Source]
+* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/attestation_task_bundle.rego#L35[Source]
 
 === Attestation Type Rules
 

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -10,6 +10,7 @@ import data.lib
 # custom:
 #   short_name: disallowed_task_reference
 #   failure_msg: Task '%s' does not contain a bundle reference
+#
 warn[result] {
 	task := lib.tasks_from_pipelinerun[_]
 	name := task.name
@@ -25,14 +26,16 @@ warn[result] {
 # custom:
 #   short_name: disallowed_task_bundle
 #   failure_msg: Task '%s' has disallowed bundle image '%s'
-#   allowed_bundles:
-#   - quay.io/redhat-appstudio/build-templates-bundle
-#   - quay.io/redhat-appstudio/hacbs-templates-bundle
-
+#   rule_data:
+#     allowed_bundles:
+#     - quay.io/redhat-appstudio/build-templates-bundle
+#     - quay.io/redhat-appstudio/hacbs-templates-bundle
+#     - quay.io/redhat-appstudio/appstudio-tasks
+#
 warn[result] {
 	task := lib.tasks_from_pipelinerun[_]
 	name := task.name
 	bundle := split(task.ref.bundle, ":")
-	not lib.item_in_list(bundle[0], rego.metadata.rule().custom.allowed_bundles)
+	not lib.item_in_list(bundle[0], rego.metadata.rule().custom.rule_data.allowed_bundles)
 	result := lib.result_helper(rego.metadata.chain(), [name, bundle[0]])
 }


### PR DESCRIPTION
This should get the e2e tests passing again.