### PR TITLE
Validate required tasks present in attestation

### DIFF
--- a/antora-docs/modules/ROOT/pages/index.adoc
+++ b/antora-docs/modules/ROOT/pages/index.adoc
@@ -191,6 +191,41 @@ registry.redhat.io/
 * Failure message: `Step %d in task '%s' has disallowed image ref '%s'`
 * https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/step_image_registries.rego#L20[Source]
 
+=== Tasks Rules
+
+[#tasks_missing]
+==== link:#tasks_missing[`tasks_missing`] No tasks run
+
+This policy enforces that at least one Task is present in the PipelineRun
+attestation.
+
+* Path: `data.policy.release.tasks.deny`
+* Failure message: `No tasks found in PipelineRun attestation`
+* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/tasks.rego#L34[Source]
+
+[#tasks_required]
+==== link:#tasks_required[`tasks_required`] Required tasks not run
+
+This policy enforces that the required set of tasks is run in a
+PipelineRun.
+
+The required task refs are:
+
+----
+add-sbom-and-push
+clamav-scan
+deprecated-image-check
+get-clair-scan
+sanity-inspect-image
+sanity-label-check
+sanity-optional-label-check
+sast-go
+----
+
+* Path: `data.policy.release.tasks.deny`
+* Failure message: `Required task(s) '%s' not found in the PipelineRun attestation`
+* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/tasks.rego#L50[Source]
+
 === Test Rules
 
 [#test_result_skipped]

--- a/docsrc/index.adoc.tmpl
+++ b/docsrc/index.adoc.tmpl
@@ -22,6 +22,8 @@ and are described here.
 
 {{ $p2_stash := "" }}
 {{ $p3_stash := "" }}
+{{/* Empty by default, set to package annotations when encountered */}}
+{{ $package_annotations := dict }}
 {{ $data := slice }}
 {{- range (datasource "rules").annotations }}
   {{- $data = $data | append (dict "key" (printf "%s:%d" .location.file .location.row) "annotation" .) }}
@@ -32,6 +34,10 @@ and are described here.
 {{ $p1 := (index (index .path 1) "value") }}
 {{ $p2 := (index (index .path 2) "value") }}
 
+{{/* Capture any package annotations */}}
+{{ if eq .annotations.scope "package" }}
+{{ $package_annotations = .annotations }}
+{{ end }}
 {{/* Skip annotations that are not rule annotations */}}
 {{ if eq .annotations.scope "rule" }}
 {{/* Skip rules that are not under data.policy */}}
@@ -67,8 +73,16 @@ These rules are applied to Tekton pipeline definitions.
 {{.annotations.description}}
 
 {{/* Show rule data if there is any */}}
-{{ if has .annotations.custom "rule_data" }}
-{{ range $key, $values := .annotations.custom.rule_data }}
+{{ $has_package_rule_data := false }}
+{{ if has $package_annotations "custom" }}
+{{ $has_package_rule_data = and (has $package_annotations.custom $name) (has (index $package_annotations.custom $name) "rule_data") }}
+{{ end }}
+{{ if or (has .annotations.custom "rule_data") $has_package_rule_data }}
+{{ $rule_data := index .annotations.custom "rule_data" }}
+{{ if $has_package_rule_data }}
+{{ $rule_data = merge $rule_data (index $package_annotations.custom $name).rule_data }}
+{{ end }}
+{{ range $key, $values := $rule_data }}
 {{/* Assume the key name is descriptive enough for this sentence to make sense */}}
 The {{ $key | strings.ReplaceAll "_" " " }} are:
 

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -1,0 +1,65 @@
+# METADATA
+# custom:
+#   tasks_required:
+#     rule_data:
+#       required_task_refs:
+#       - add-sbom-and-push
+#       - clamav-scan
+#       - deprecated-image-check
+#       - get-clair-scan
+#       - sanity-inspect-image
+#       - sanity-label-check
+#       - sanity-optional-label-check
+#       - sast-go
+package policy.release.tasks
+
+import data.lib
+import future.keywords.in
+
+# This generates all errors that can be omitted from the `tasks_required`
+# rule. Since required tasks can change over time, we need this so we
+# don't need to repeat the list of tasks in the test where this list of
+# errors is also used. It needs to be placed here to be able to access
+# the package level metadata/annotations above.
+all_required_tasks := {t | t := rego.metadata.chain()[_].annotations.custom.tasks_required.rule_data.required_task_refs[_]}
+
+# METADATA
+# title: No tasks run
+# description: |-
+#   This policy enforces that at least one Task is present in the PipelineRun
+#   attestation.
+# custom:
+#   short_name: tasks_missing
+#   failure_msg: No tasks found in PipelineRun attestation
+deny[result] {
+	att := lib.pipelinerun_attestations[_]
+
+	count(att.predicate.buildConfig.tasks) == 0
+
+	result := lib.result_helper(rego.metadata.chain(), [])
+}
+
+# METADATA
+# title: Required tasks not run
+# description: |-
+#   This policy enforces that the required set of tasks is run in a
+#   PipelineRun.
+# custom:
+#   short_name: tasks_required
+#   failure_msg: Required task(s) '%s' not found in the PipelineRun attestation
+deny[result] {
+	att := lib.pipelinerun_attestations[_]
+
+	# reported by tasks_missing above
+	count(att.predicate.buildConfig.tasks) > 0
+
+	# collects names of tasks that are present in the attestation
+	attested_tasks := {t | att.predicate.buildConfig.tasks[_].ref.kind == "Task"; t := att.predicate.buildConfig.tasks[_].ref.name}
+
+	# if all attested_tasks equal all_required_tasks this set is empty,
+	# otherwise it contains the tasks that are required but are not
+	# present in the attestation
+	all_missing := all_required_tasks - attested_tasks
+
+	result := lib.result_helper(rego.metadata.chain(), [concat("', '", all_missing)])
+}

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -1,0 +1,76 @@
+package policy.release.tasks
+
+import data.lib
+
+test_no_tasks_present {
+	expected := {{
+		"code": "tasks_missing",
+		"msg": "No tasks found in PipelineRun attestation",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}
+
+	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+		"buildType": lib.pipelinerun_att_build_type,
+		"buildConfig": {"tasks": []},
+	}}]
+}
+
+test_empty_task_attested {
+	expected := missing_tasks_error(all_required_tasks)
+
+	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+		"buildType": lib.pipelinerun_att_build_type,
+		"buildConfig": {"tasks": [{}]},
+	}}]
+}
+
+test_all_required_tasks_not_present {
+	expected := missing_tasks_error(all_required_tasks)
+
+	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+		"buildType": lib.pipelinerun_att_build_type,
+		"buildConfig": {"tasks": [{"ref": {"name": "custom", "kind": "Task"}}]},
+	}}]
+}
+
+test_all_but_one_required_task_not_present {
+	expected := missing_tasks_error(all_required_tasks - {"sanity-inspect-image"})
+
+	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+		"buildType": lib.pipelinerun_att_build_type,
+		"buildConfig": {"tasks": [{"ref": {"name": "sanity-inspect-image", "kind": "Task"}}]},
+	}}]
+}
+
+test_several_tasks_not_present {
+	expected := missing_tasks_error(all_required_tasks - {"sanity-inspect-image", "clamav-scan", "add-sbom-and-push"})
+
+	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+		"buildType": lib.pipelinerun_att_build_type,
+		"buildConfig": {"tasks": [
+			{"ref": {"name": "sanity-inspect-image", "kind": "Task"}},
+			{"ref": {"name": "clamav-scan", "kind": "Task"}},
+			{"ref": {"name": "add-sbom-and-push", "kind": "Task"}},
+		]},
+	}}]
+}
+
+test_tricks {
+	expected := missing_tasks_error(all_required_tasks)
+
+	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+		"buildType": lib.pipelinerun_att_build_type,
+		"buildConfig": {"tasks": [
+			{"name": "sanity-inspect-image"},
+			{"ref": {"name": "sanity-inspect-image", "kind": "NotTask"}},
+		]},
+	}}]
+}
+
+missing_tasks_error(missing) = error {
+	error := {{
+		"code": "tasks_required",
+		"msg": sprintf("Required task(s) '%s' not found in the PipelineRun attestation", [concat("', '", missing)]),
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}
+}


### PR DESCRIPTION
This adds two policy checks: `tasks_missing` if there are no tasks in the PipelineRun attestation; and `tasks_required` if the required tasks are not present in the PipelineRun attestation.

In addition to custom annotation for `rule_data` in the rule scope, this also allows custom `rule_data` annotation at the package scope that is nested within the rule's short name. In this case this was necessary so that the list of required tasks is not repeated between the test and the rule implementation. This allows us to define `rule_data` for the `tasks_required` rule and the tests in the single location.

Ref. https://issues.redhat.com/browse/HACBS-676