### PR TITLE
Order OPA inspect data within doc template

### DIFF
--- a/antora-docs/modules/ROOT/pages/index.adoc
+++ b/antora-docs/modules/ROOT/pages/index.adoc
@@ -178,6 +178,15 @@ registry.redhat.io/
 
 === Test Rules
 
+[#test_result_skipped]
+==== link:#test_result_skipped[`test_result_skipped`] Some tests were skipped
+
+Collects all tests that have their result set to "SKIPPED".
+
+* Path: `data.policy.release.test.warn`
+* Failure message: `The following tests were skipped: %s`
+* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/test.rego#L103[Source]
+
 [#test_data_missing]
 ==== link:#test_data_missing[`test_data_missing`] No test data found
 
@@ -229,15 +238,6 @@ the failure message will list the names of the failing tests.
 * Path: `data.policy.release.test.deny`
 * Failure message: `The following tests did not complete successfully: %s`
 * https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/test.rego#L74[Source]
-
-[#test_result_skipped]
-==== link:#test_result_skipped[`test_result_skipped`] Some tests were skipped
-
-Collects all tests that have their result set to "SKIPPED".
-
-* Path: `data.policy.release.test.warn`
-* Failure message: `The following tests were skipped: %s`
-* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/test.rego#L103[Source]
 
 See Also
 --------

--- a/docsrc/index.adoc.tmpl
+++ b/docsrc/index.adoc.tmpl
@@ -22,7 +22,12 @@ and are described here.
 
 {{ $p2_stash := "" }}
 {{ $p3_stash := "" }}
-{{ range (datasource "rules").annotations }}
+{{ $data := slice }}
+{{- range (datasource "rules").annotations }}
+  {{- $data = $data | append (dict "key" (printf "%s:%d" .location.file .location.row) "annotation" .) }}
+{{ end }}
+{{ range $data | sort "key" }}
+{{ with .annotation }}
 
 {{ $p1 := (index (index .path 1) "value") }}
 {{ $p2 := (index (index .path 2) "value") }}
@@ -83,6 +88,7 @@ The {{ $key | strings.ReplaceAll "_" " " }} are:
 
 {{ end }}{{/* if eq $p1 ... */}}
 {{ end }}{{/* if eq .annotations ... */}}
+{{ end }}{{/* with .annotation */}}
 {{ end }}{{/* range ... */}}
 
 See Also


### PR DESCRIPTION
Seems that the order of keys in data from `opa inspect` can vary, it is
also unclear if unmarshalling the resulting JSON can lead to it being
reordered due to golang's map hashing algorithm. To achieve
deterministic output in the docs this sorts the data by location: rule
file path and line number of the rule's definition; in the documentation
template.