### PR TITLE
Removes the unused Jekyll documentation setup

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,0 @@
-
-HACBS Enterprise Contract Policies
-==================================
-
-The policy rule documentation has moved to the official [HACBS
-Documentation](https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/ec-policies/index.html).
-
-(This page will be retired soon.)


### PR DESCRIPTION
This is no longer needed with the Antora setup we have.