### PR TITLE
Local Antora build and preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ data/config.json
 input/
 public/
 .cache/
+*.swp


### PR DESCRIPTION
Adds two targets to the `Makefile` to build the documentation locally:
`docs-build-local` and to run in preview mode: `docs-preview`, that
rebuilds as the configuration or the documentation changes.

Both need a recent Node.js installation.