### PR TITLE
Render documentation from local source always

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,9 +26,7 @@ jobs:
           key: ${{ runner.os }}-antora-cache
 
       - name: Run Antora
-        uses: kameshsampath/antora-site-action@3fcb79815255c9d39edf9013aae94c401b536df6
-        with:
-          antora_playbook: antora-playbook.yml
+        run: make docs-render
 
       - name: Setup Pages
         uses: actions/configure-pages@v1

--- a/Makefile
+++ b/Makefile
@@ -117,17 +117,8 @@ docs-build: build-docs
 docs-amend: amend-docs
 fmt-amend: amend-fmt
 
-.ONESHELL:
-.SHELLFLAGS=-e -c
-docs-build-local: ## Builds the Antora documentation with the local changes
-	@local_playbook=$$(mktemp --suffix=.yaml --tmpdir=.)
-	@function cleanup() {
-		rm "$${local_playbook}"
-	}
-	@trap cleanup EXIT
-# Replaces the source to point to local files and builds the HTML files to the `public` directory
-	@yq -e '.content.sources[0].url="." | .content.sources[0].branches="HEAD"' antora-playbook.yml > "$${local_playbook}"
-	@npm exec -y --quiet antora generate "$${local_playbook}"
+docs-render: ## Builds the Antora documentation with the local changes
+	@npm exec -y --quiet antora generate --clean --fetch antora-playbook.yml
 
 # Do `dnf install entr` then run this a separate terminal or split window while hacking
 .ONESHELL:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,9 +10,9 @@ site:
   robots: allow
 content:
   sources:
-    - url: https://github.com/hacbs-contract/ec-policies.git
+    - url: .
       start_path: antora-docs
-      branches: main
+      branches: HEAD
 ui:
   bundle:
     url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable


### PR DESCRIPTION
To prevent checking out the repository twice we can build from local
checkout in all cases (for `docs-render` and `docs-preview` targets).
This both simplifies the rendering and makes it deterministic, as we
didn't specify `--fetch` which would go through the Antora cache and
possibly use an older version of the documentation.

This way we also don't require the GitHub Action to render, and can use
the `docs-render` target from the Makefile, so one less item to
maintain.