### PR TITLE
Rule to assert Java dependency provenance

### DIFF
--- a/antora-docs/modules/ROOT/pages/release_policy.adoc
+++ b/antora-docs/modules/ROOT/pages/release_policy.adoc
@@ -108,6 +108,27 @@ Enterprise Contract verifies if an authorized repo url was used to build an imag
 * Short name: `disallowed_repo_url_does_not_match`
 * https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/authorization.rego#L40[Source, window="_blank"]
 
+== Java Rules
+
+[#java_foreign_dependencies]
+=== link:#java_foreign_dependencies[Prevent Java builds from depending on foreign dependencies]
+
+The SBOM_JAVA_COMPONENTS_COUNT TaskResult finds dependencies that have
+originated from foreign repositories, i.e. ones that are not rebuilt or
+redhat.
+
+The allowed component sources are:
+
+----
+redhat
+rebuilt
+----
+
+* Rule type: [rule-type-indicator deny]#FAILURE#
+* Failure message: `Found Java dependencies from '%s', expecting to find only from '%s'`
+* Short name: `java_foreign_dependencies`
+* https://github.com/hacbs-contract/ec-policies/blob/main/policy/release/java.rego#L19[Source, window="_blank"]
+
 == Not Useful Rules
 
 [#bad_day]

--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -1,0 +1,35 @@
+package policy.release.java
+
+import data.lib
+import future.keywords.in
+
+# METADATA
+# title: Prevent Java builds from depending on foreign dependencies
+# description: |-
+#   The SBOM_JAVA_COMPONENTS_COUNT TaskResult finds dependencies that have
+#   originated from foreign repositories, i.e. ones that are not rebuilt or
+#   redhat.
+# custom:
+#   short_name: java_foreign_dependencies
+#   failure_msg: Found Java dependencies from '%s', expecting to find only from '%s'
+#   rule_data:
+#     allowed_component_sources:
+#       - redhat
+#       - rebuilt
+deny[result] {
+	results := lib.results_named(lib.java_sbom_component_count_result_name)
+
+	# convert to set
+	allowed := {a | a := rego.metadata.rule().custom.rule_data.allowed_component_sources[_]}
+
+	# contains names of dependency sources that are foreign, i.e. not one of
+	# allowed_component_sources
+	foreign := [name |
+		results[_][name]
+		not name in (allowed | {lib.task_name})
+	]
+
+	count(foreign) > 0
+
+	result := lib.result_helper(rego.metadata.chain(), [concat(",", foreign), concat(",", allowed)])
+}

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -1,0 +1,13 @@
+package policy.release.java
+
+import data.lib
+
+test_all_good {
+	attestations := [lib.att_mock_helper(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42}, "java-task-1")]
+	lib.assert_empty(deny) with input.attestations as attestations
+}
+
+test_has_foreign {
+	attestations := [lib.att_mock_helper(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42, "central": 1}, "java-task-1")]
+	lib.assert_equal(deny, {{"code": "java_foreign_dependencies", "effective_on": "2022-01-01T00:00:00Z", "msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'"}}) with input.attestations as attestations
+}

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -13,11 +13,11 @@ mock_tr_att := {"predicate": {"buildType": tr_build_type}}
 garbage_att := {"predicate": {"buildType": "garbage"}}
 
 # Used also in main_test and test_test
-att_mock_helper(result_map, task_name) = d {
+att_mock_helper(name, result_map, task_name) = d {
 	d := {"predicate": {
 		"buildType": pipelinerun_att_build_type,
 		"buildConfig": {"tasks": [{"name": task_name, "results": [{
-			"name": hacbs_test_task_result_name,
+			"name": name,
 			"value": json.marshal(result_map),
 		}]}]},
 	}}
@@ -54,17 +54,17 @@ test_att_mock_helper {
 	expected := {"predicate": {
 		"buildType": pipelinerun_att_build_type,
 		"buildConfig": {"tasks": [{"name": "mytask", "results": [{
-			"name": hacbs_test_task_result_name,
+			"name": "result-name",
 			"value": "{\"foo\":\"bar\"}",
 		}]}]},
 	}}
 
-	assert_equal(expected, lib.att_mock_helper({"foo": "bar"}, "mytask"))
+	assert_equal(expected, lib.att_mock_helper("result-name", {"foo": "bar"}, "mytask"))
 }
 
 test_results_from_tests {
-	expected := {"result": "SUCCESS", "foo": "bar", "__task_name": "mytask"}
-	assert_equal([expected], results_from_tests) with input.attestations as [att_mock_helper({"result": "SUCCESS", "foo": "bar"}, "mytask")]
+	expected := {"result": "SUCCESS", "foo": "bar", lib.task_name: "mytask"}
+	assert_equal([expected], results_from_tests) with input.attestations as [att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCCESS", "foo": "bar"}, "mytask")]
 }
 
 test_task_in_pipelinerun {

--- a/policy/release/main_test.rego
+++ b/policy/release/main_test.rego
@@ -51,7 +51,7 @@ test_test_can_be_skipped {
 }
 
 test_test_succeeds {
-	lib.assert_empty(deny) with input.attestations as [lib.att_mock_helper({"result": "SUCCESS"}, "mytask")] with data.config.policy as nonblocking_except({"test"})
+	lib.assert_empty(deny) with input.attestations as [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "mytask")] with data.config.policy as nonblocking_except({"test"})
 }
 
 test_test_fails {
@@ -59,7 +59,7 @@ test_test_fails {
 		"code": "test_result_failures",
 		"msg": "The following tests did not complete successfully: test1",
 		"effective_on": "2022-01-01T00:00:00Z",
-	}}) with input.attestations as [lib.att_mock_helper({"result": "FAILURE"}, "test1")] with data.config.policy as nonblocking_except({"test"})
+	}}) with input.attestations as [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "test1")] with data.config.policy as nonblocking_except({"test"})
 }
 
 test_policy_ignored_when_not_yet_effective {

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -3,11 +3,7 @@ package policy.release.test
 import data.lib
 
 # Because HACBS_TEST_OUTPUT isn't in the task results, the lib.results_from_tests will be empty
-mock_empty_data := [json.patch(lib.att_mock_helper({}, "task1"), [{
-	"op": "replace",
-	"path": "/predicate/buildConfig/tasks/0/results/0/name",
-	"value": "NOT_HACBS_TEST_OUTPUT",
-}])]
+mock_empty_data := [lib.att_mock_helper("NOT_HACBS_TEST_OUTPUT", {}, "task1")]
 
 test_needs_non_empty_data {
 	lib.assert_equal(deny, {{
@@ -18,7 +14,7 @@ test_needs_non_empty_data {
 }
 
 # There is a test result, but the data inside it doesn't include the "result" key
-mock_without_results_data := [lib.att_mock_helper({"rezult": "SUCCESS"}, "task1")]
+mock_without_results_data := [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"rezult": "SUCCESS"}, "task1")]
 
 test_needs_tests_with_results {
 	lib.assert_equal(deny, {{
@@ -29,8 +25,8 @@ test_needs_tests_with_results {
 }
 
 mock_without_results_data_mixed := [
-	lib.att_mock_helper({"result": "SUCCESS"}, "task1"),
-	lib.att_mock_helper({"rezult": "SUCCESS"}, "task2"),
+	lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "task1"),
+	lib.att_mock_helper(lib.hacbs_test_task_result_name, {"rezult": "SUCCESS"}, "task2"),
 ]
 
 test_needs_tests_with_results_mixed {
@@ -41,14 +37,14 @@ test_needs_tests_with_results_mixed {
 	}}) with input.attestations as mock_without_results_data_mixed
 }
 
-mock_a_passing_test := [lib.att_mock_helper({"result": "SUCCESS"}, "task1")]
+mock_a_passing_test := [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "task1")]
 
 test_success_data {
 	lib.assert_empty(deny) with input.attestations as mock_a_passing_test
 		with data.config.policy as {"non_blocking_checks": []}
 }
 
-mock_a_failing_test := [lib.att_mock_helper({"result": "FAILURE"}, "failed_1")]
+mock_a_failing_test := [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "failed_1")]
 
 test_failure_data {
 	lib.assert_equal(deny, {{
@@ -59,7 +55,7 @@ test_failure_data {
 		with data.config.policy as {"non_blocking_checks": []}
 }
 
-mock_an_errored_test := [lib.att_mock_helper({"result": "ERROR"}, "errored_1")]
+mock_an_errored_test := [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "errored_1")]
 
 test_error_data {
 	lib.assert_equal(deny, {{
@@ -94,12 +90,12 @@ test_can_skip_by_name {
 }
 
 test_skipped_is_not_deny {
-	skipped_test := [lib.att_mock_helper({"result": "SKIPPED"}, "skipped_1")]
+	skipped_test := [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_1")]
 	lib.assert_empty(deny) with input.attestations as skipped_test
 }
 
 test_skipped_is_warning {
-	skipped_test := [lib.att_mock_helper({"result": "SKIPPED"}, "skipped_1")]
+	skipped_test := [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_1")]
 	lib.assert_equal(warn, {{
 		"code": "test_result_skipped",
 		"msg": "The following tests were skipped: skipped_1",
@@ -109,13 +105,13 @@ test_skipped_is_warning {
 
 test_mixed_statuses {
 	test_results := [
-		lib.att_mock_helper({"result": "ERROR"}, "error_1"),
-		lib.att_mock_helper({"result": "SUCCESS"}, "success_1"),
-		lib.att_mock_helper({"result": "FAILURE"}, "failure_1"),
-		lib.att_mock_helper({"result": "SKIPPED"}, "skipped_1"),
-		lib.att_mock_helper({"result": "FAILURE"}, "failure_2"),
-		lib.att_mock_helper({"result": "SKIPPED"}, "skipped_2"),
-		lib.att_mock_helper({"result": "ERROR"}, "error_2"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "error_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "success_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "failure_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "failure_2"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_2"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "error_2"),
 	]
 
 	lib.assert_equal(deny, {{
@@ -133,10 +129,10 @@ test_mixed_statuses {
 
 test_unsupported_test_result {
 	test_results := [
-		lib.att_mock_helper({"result": "EROR"}, "error_1"),
-		lib.att_mock_helper({"result": "SUCESS"}, "success_1"),
-		lib.att_mock_helper({"result": "FAIL"}, "failure_1"),
-		lib.att_mock_helper({"result": "SKIPED"}, "skipped_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "EROR"}, "error_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCESS"}, "success_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "FAIL"}, "failure_1"),
+		lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SKIPED"}, "skipped_1"),
 	]
 
 	lib.assert_equal(deny, {


### PR DESCRIPTION
Adds a new rule to assert that the `SBOM_JAVA_COMPONENTS_COUNT` result
contains only `redhat` and `rebuilt` counts.

Ref. https://issues.redhat.com/browse/HACBS-931