### PR TITLE
Add task bundle rules for pipeline package

### DIFF
--- a/policy/lib/bundles.rego
+++ b/policy/lib/bundles.rego
@@ -1,0 +1,117 @@
+package lib.bundles
+
+import data.lib.image
+import data.lib.time as time_lib
+
+# Returns a subset of tasks that do not use a bundle reference.
+disallowed_task_reference(tasks) = matches {
+	matches := {task |
+		task := tasks[_]
+		not bundle(task)
+	}
+}
+
+# Returns a subset of tasks that use an empty bundle reference.
+empty_task_bundle_reference(tasks) = matches {
+	matches := {task |
+		task := tasks[_]
+		bundle(task) == ""
+	}
+}
+
+# Returns a subset of tasks that use an acceptable bundle reference, but
+# an updated bundle reference exists.
+out_of_date_task_bundle(tasks) = matches {
+	matches := {task |
+		task := tasks[_]
+		ref := image.parse(bundle(task))
+		collection := _collection(ref)
+
+		collection[match_index].digest == ref.digest
+		match_index > 0
+	}
+}
+
+# Returns a subset of tasks that do not use an acceptable bundle reference.
+unacceptable_task_bundle(tasks) = matches {
+	matches := {task |
+		task := tasks[_]
+		ref := image.parse(bundle(task))
+		collection := _collection(ref)
+
+		matches := [record |
+			record := collection[_]
+			record.digest == ref.digest
+		]
+
+		count(matches) == 0
+	}
+}
+
+# Extract the bundle reference value from a Task that is found
+# within a PipelineRun attestations.
+bundle(task) = b {
+	b := task.ref.bundle
+}
+
+# Extract the bundle reference value from a Task that is found
+# within a Pipeline definition.
+bundle(task) = b {
+	b := task.taskRef.bundle
+}
+
+# _collection returns an array representing the full list of records to
+# be taken into consideration when evaluating policy rules for bundle
+# references. Any irrelevant records are filtered out from the array.
+_collection(ref) = items {
+	full_collection := data["task-bundles"][ref.repo]
+	stream_collection := _collection_by_stream(full_collection, ref)
+	items := time_lib.acceptable_items(stream_collection)
+}
+
+# _collection_by_stream returns a filtered array where each item has
+# the same stream value as the given ref.
+#
+# Some OCI repositories may contain multiple sets of images that are
+# actively updated. Each of these sets is called a stream. In such
+# cases, it is necessary to split the collection into multiple stream
+# collections so the policy can be properly applied. See the _stream
+# docs for an explanation of the stream identification process.
+_collection_by_stream(items, ref) = some_items {
+	tag := _tag_by_digest(items, ref)
+	stream := _stream(tag)
+	some_items := [item |
+		item := items[_]
+		_stream(item.tag) == stream
+	]
+}
+
+_stream_regex := `^[a-f0-9]{40}(-\d+)$`
+
+# _stream computes the stream of the given image tag. If the tag matches
+# the _stream_regex, then the stream is the last matched group. Otherwise
+# the stream is "default".
+_stream(tag) = stream {
+	regex.match(_stream_regex, tag)
+	parts := split(tag, "-")
+	stream := parts[count(parts) - 1]
+} else = "default" {
+	true
+}
+
+# _tag_by_digest determines the tag of the image reference based on the
+# possiblities in the given collection. This is useful to ensure streams
+# can be properly computed for image references where only the digest is
+# provided. If the image reference already has a tag, that value is
+# always returned.
+_tag_by_digest(collection, ref) = new_tag {
+	ref.tag == ""
+	selected := [item |
+		item := collection[_]
+		item.digest == ref.digest
+	]
+
+	new_tag := selected[0].tag
+} else = ref.tag {
+	true
+}

--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -1,0 +1,198 @@
+package lib.bundles
+
+import data.lib
+
+test_disallowed_task_reference {
+	tasks := [
+		{"name": "my-task-1", "taskRef": {}},
+		{"name": "my-task-2", "ref": {}},
+	]
+
+	expected := {task | task := tasks[_]}
+	lib.assert_equal(disallowed_task_reference(tasks), expected)
+}
+
+test_empty_task_bundle_reference {
+	tasks := [
+		{"name": "my-task-1", "taskRef": {"bundle": ""}},
+		{"name": "my-task-2", "ref": {"bundle": ""}},
+	]
+
+	expected := {task | task := tasks[_]}
+	lib.assert_equal(empty_task_bundle_reference(tasks), expected)
+}
+
+# All good when the most recent bundle is used.
+test_acceptable_bundle {
+	tasks := [
+		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:abc"}},
+		{"name": "my-task-2", "ref": {"bundle": "reg.com/repo@sha256:abc"}},
+	]
+
+	lib.assert_empty(disallowed_task_reference(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(empty_task_bundle_reference(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(out_of_date_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(unacceptable_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+}
+
+# All good when the most recent bundle is used when streams are used.
+test_acceptable_bundle_up_to_date_with_streams {
+	tasks := [
+		{
+			"name": "my-task-1",
+			"taskRef": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2@sha256:abc"},
+		},
+		{
+			"name": "my-task-2",
+			"ref": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2@sha256:abc"},
+		},
+	]
+
+	lib.assert_empty(disallowed_task_reference(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(empty_task_bundle_reference(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(out_of_date_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+	lib.assert_empty(unacceptable_task_bundle(tasks)) with data["task-bundles"] as task_bundles
+}
+
+test_out_of_date_task_bundle {
+	tasks := [
+		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:bcd"}},
+		{"name": "my-task-2", "taskRef": {"bundle": "reg.com/repo@sha256:cde"}},
+		{"name": "my-task-3", "ref": {"bundle": "reg.com/repo@sha256:bcd"}},
+		{"name": "my-task-4", "ref": {"bundle": "reg.com/repo@sha256:cde"}},
+	]
+
+	expected := {task | task := tasks[_]}
+	lib.assert_equal(out_of_date_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+}
+
+test_out_of_date_task_bundle_with_streams {
+	# Verify streams are honored
+	tasks := [
+		{
+			"name": "my-task-1",
+			"taskRef": {"bundle": "reg.com/repo:b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2@sha256:bcd"},
+		},
+		{
+			"name": "my-task-2",
+			"taskRef": {"bundle": "reg.com/repo:120dda49a6cc3b89516b491e19fe1f3a07f1427f-2@sha256:cde"},
+		},
+		{
+			"name": "my-task-3",
+			"taskRef": {"bundle": "reg.com/repo:b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2@sha256:bcd"},
+		},
+		{
+			"name": "my-task-4",
+			"taskRef": {"bundle": "reg.com/repo:120dda49a6cc3b89516b491e19fe1f3a07f1427f-2@sha256:cde"},
+		},
+	]
+
+	expected := {task | task := tasks[_]}
+	lib.assert_equal(out_of_date_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+}
+
+test_unacceptable_task_bundles {
+	tasks := [
+		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:def"}},
+		{"name": "my-task-2", "ref": {"bundle": "reg.com/repo@sha256:def"}},
+	]
+
+	expected := {task | task := tasks[_]}
+	lib.assert_equal(unacceptable_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+}
+
+test_unacceptable_task_bundles_with_streams {
+	tasks := [
+		{
+			"name": "my-task-1",
+			"taskRef": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-1@sha256:def"},
+		},
+		{
+			"name": "my-task-2",
+			"ref": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-1@sha256:def"},
+		},
+	]
+
+	expected := {task | task := tasks[_]}
+	lib.assert_equal(unacceptable_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
+}
+
+test_stream {
+	lib.assert_equal(_stream(""), "default")
+	lib.assert_equal(_stream("spam"), "default")
+	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5"), "default")
+	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-9-9"), "default")
+	lib.assert_equal(_stream("spam-903d49a833d22f359bce3d67b15b006e1197bae5-2"), "default")
+
+	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-2"), "2")
+	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-999"), "999")
+}
+
+test_tag_by_digest {
+	refs := [
+		{
+			"digest": "sha256:abc",
+			"tag": "ignore-me",
+		},
+		{
+			"digest": "sha256:bcd",
+			"tag": "the-tag",
+		},
+		{
+			"digest": "sha256:bcd",
+			"tag": "repeat-digest",
+		},
+	]
+
+	# The first match is found
+	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:bcd", "tag": ""}), "the-tag")
+
+	# Skip search if tag is already provided
+	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:bcd", "tag": "tag-known"}), "tag-known")
+
+	# No match found
+	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:cde", "tag": ""}), "")
+}
+
+task_bundles = {"reg.com/repo": [
+	{
+		"digest": "sha256:012", # Ignore
+		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-1",
+		"effective_on": "2262-04-11T00:00:00Z",
+	},
+	{
+		"digest": "sha256:abc", # Allow
+		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-2",
+		"effective_on": "2262-04-11T00:00:00Z",
+	},
+	{
+		"digest": "sha256:123", # Ignore
+		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-1",
+		"effective_on": "2262-03-11T00:00:00Z",
+	},
+	{
+		"digest": "sha256:bcd", # Warn
+		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2",
+		"effective_on": "2262-03-11T00:00:00Z",
+	},
+	{
+		"digest": "sha256:234", # Ignore
+		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f-1",
+		"effective_on": "2022-02-01T00:00:00Z",
+	},
+	{
+		"digest": "sha256:cde", # Warn
+		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f-2",
+		"effective_on": "2022-02-01T00:00:00Z",
+	},
+	{
+		"digest": "sha256:345", # Ignore
+		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-1",
+		"effective_on": "2021-01-01T00:00:00Z",
+	},
+	{
+		"digest": "sha256:def", # Warn
+		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-2",
+		"effective_on": "2021-01-01T00:00:00Z",
+	},
+]}

--- a/policy/pipeline/task_bundle.rego
+++ b/policy/pipeline/task_bundle.rego
@@ -1,4 +1,4 @@
-package policy.release.attestation_task_bundle
+package policy.pipeline.task_bundle
 
 import data.lib
 import data.lib.bundles
@@ -13,7 +13,7 @@ import data.lib.bundles
 #   failure_msg: Pipeline task '%s' does not contain a bundle reference
 #
 deny[result] {
-	name := bundles.disallowed_task_reference(lib.tasks_from_pipelinerun)[_].name
+	name := bundles.disallowed_task_reference(input.spec.tasks)[_].name
 	result := lib.result_helper(rego.metadata.chain(), [name])
 }
 
@@ -26,14 +26,14 @@ deny[result] {
 #   failure_msg: Pipeline task '%s' uses an empty bundle image reference
 #
 deny[result] {
-	name := bundles.empty_task_bundle_reference(lib.tasks_from_pipelinerun)[_].name
+	name := bundles.empty_task_bundle_reference(input.spec.tasks)[_].name
 	result := lib.result_helper(rego.metadata.chain(), [name])
 }
 
 # METADATA
 # title: Task bundle is out of date
 # description: |-
-#   Check if the Tekton Bundle used for the Tasks in the attestation
+#   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   is the most recent acceptable one. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
 #   link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
@@ -43,14 +43,14 @@ deny[result] {
 #   failure_msg: Pipeline task '%s' uses an out of date task bundle '%s'
 #
 warn[result] {
-	task := bundles.out_of_date_task_bundle(lib.tasks_from_pipelinerun)[_]
+	task := bundles.out_of_date_task_bundle(input.spec.tasks)[_]
 	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
 }
 
 # METADATA
 # title: Task bundle is not acceptable
 # description: |-
-#   Check if the Tekton Bundle used for the Tasks in the attestation
+#   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   are acceptable given the tracked effective_on date. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
 #   link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
@@ -60,6 +60,6 @@ warn[result] {
 #   failure_msg: Pipeline task '%s' uses an unacceptable task bundle '%s'
 #
 deny[result] {
-	task := bundles.unacceptable_task_bundle(lib.tasks_from_pipelinerun)[_]
+	task := bundles.unacceptable_task_bundle(input.spec.tasks)[_]
 	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
 }

--- a/policy/pipeline/task_bundle.rego
+++ b/policy/pipeline/task_bundle.rego
@@ -31,6 +31,20 @@ deny[result] {
 }
 
 # METADATA
+# title: Unpinned task bundle reference
+# description: |-
+#   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
+#   is pinned to a digest.
+# custom:
+#   short_name: unpinned_task_bundle
+#   failure_msg: Pipeline task '%s' uses an unpinned task bundle reference '%s'
+#
+warn[result] {
+	task := bundles.unpinned_task_bundle(input.spec.tasks)[_]
+	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
+}
+
+# METADATA
 # title: Task bundle is out of date
 # description: |-
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -28,10 +28,24 @@ test_bundle_not_exists_empty_string {
 	lib.assert_empty(warn) with input.spec.tasks as tasks
 }
 
+test_bundle_unpinned {
+	tasks := [{
+		"name": "my-task",
+		"taskRef": {"bundle": "reg.com/repo:latest"},
+	}]
+
+	lib.assert_empty(deny) with input.spec.tasks as tasks
+	lib.assert_equal(warn, {{
+		"code": "unpinned_task_bundle",
+		"msg": "Pipeline task 'my-task' uses an unpinned task bundle reference 'reg.com/repo:latest'",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.spec.tasks as tasks
+}
+
 test_bundle_reference_valid {
 	tasks := [{
 		"name": "my-task",
-		"taskRef": {"bundle": "quay.io/redhat-appstudio/hacbs-templates-bundle:latest"},
+		"taskRef": {"bundle": "quay.io/redhat-appstudio/hacbs-templates-bundle:latest@sha256:abc"},
 	}]
 
 	lib.assert_empty(deny) with input.spec.tasks as tasks

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -1,0 +1,117 @@
+package policy.pipeline.task_bundle
+
+import data.lib
+
+test_bundle_not_exists {
+	tasks := [{"name": "my-task", "taskRef": {}}]
+
+	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
+	lib.assert_equal(deny, {{
+		"code": "disallowed_task_reference",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.spec.tasks as tasks
+
+	lib.assert_empty(warn) with input.spec.tasks as tasks
+}
+
+test_bundle_not_exists_empty_string {
+	tasks := [{"name": "my-task", "taskRef": {"bundle": ""}}]
+
+	expected_msg := "Pipeline task 'my-task' uses an empty bundle image reference"
+	lib.assert_equal(deny, {{
+		"code": "empty_task_bundle_reference",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.spec.tasks as tasks
+
+	lib.assert_empty(warn) with input.spec.tasks as tasks
+}
+
+test_bundle_reference_valid {
+	tasks := [{
+		"name": "my-task",
+		"taskRef": {"bundle": "quay.io/redhat-appstudio/hacbs-templates-bundle:latest"},
+	}]
+
+	lib.assert_empty(deny) with input.spec.tasks as tasks
+	lib.assert_empty(warn) with input.spec.tasks as tasks
+}
+
+# All good when the most recent bundle is used.
+test_acceptable_bundle_up_to_date {
+	tasks := [{"name": "my-task", "taskRef": {"bundle": "reg.com/repo@sha256:abc"}}]
+
+	lib.assert_empty(warn) with input.spec.tasks as tasks
+		with data["task-bundles"] as task_bundles
+
+	lib.assert_empty(deny) with input.spec.tasks as tasks
+		with data["task-bundles"] as task_bundles
+}
+
+# Warn about out of date bundles that are still acceptable.
+test_acceptable_bundle_out_of_date_past {
+	tasks := [
+		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:bcd"}},
+		{"name": "my-task-2", "taskRef": {"bundle": "reg.com/repo@sha256:cde"}},
+	]
+
+	lib.assert_equal(warn, {
+		{
+			"code": "out_of_date_task_bundle",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Pipeline task 'my-task-1' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
+		},
+		{
+			"code": "out_of_date_task_bundle",
+			"effective_on": "2022-01-01T00:00:00Z",
+			"msg": "Pipeline task 'my-task-2' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
+		},
+	}) with input.spec.tasks as tasks
+		with data["task-bundles"] as task_bundles
+
+	lib.assert_empty(deny) with input.spec.tasks as tasks
+		with data["task-bundles"] as task_bundles
+}
+
+# Deny bundles that are no longer active.
+test_acceptable_bundle_expired {
+	tasks := [{"name": "my-task", "taskRef": {"bundle": "reg.com/repo@sha256:def"}}]
+
+	lib.assert_empty(warn) with input.spec.tasks as tasks
+		with data["task-bundles"] as task_bundles
+
+	lib.assert_equal(deny, {{
+		"code": "unacceptable_task_bundle",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Pipeline task 'my-task' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
+	}}) with input.spec.tasks as tasks
+		with data["task-bundles"] as task_bundles
+}
+
+task_bundles = {"reg.com/repo": [
+	{
+		# Latest bundle, allowed
+		"digest": "sha256:abc",
+		"tag": "",
+		"effective_on": "2262-04-11T00:00:00Z",
+	},
+	{
+		# Recent bundle effective in the future, allowed but warn to upgrade
+		"digest": "sha256:bcd",
+		"tag": "",
+		"effective_on": "2262-03-11T00:00:00Z",
+	},
+	{
+		# Recent bundle effective in the past, allowed but warn to upgrade
+		"digest": "sha256:cde",
+		"tag": "",
+		"effective_on": "2022-02-01T00:00:00Z",
+	},
+	{
+		# Old bundle, denied
+		"digest": "sha256:def",
+		"tag": "",
+		"effective_on": "2021-01-01T00:00:00Z",
+	},
+]}

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -31,6 +31,20 @@ deny[result] {
 }
 
 # METADATA
+# title: Unpinned task bundle reference
+# description: |-
+#   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
+#   is pinned to a digest.
+# custom:
+#   short_name: unpinned_task_bundle
+#   failure_msg: Pipeline task '%s' uses an unpinned task bundle reference '%s'
+#
+warn[result] {
+	task := bundles.unpinned_task_bundle(lib.tasks_from_pipelinerun)[_]
+	result := lib.result_helper(rego.metadata.chain(), [task.name, bundles.bundle(task)])
+}
+
+# METADATA
 # title: Task bundle is out of date
 # description: |-
 #   Check if the Tekton Bundle used for the Tasks in the attestation

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -16,7 +16,7 @@ test_bundle_not_exists {
 		"ref": {"name": "good-task"},
 	})
 
-	expected_msg := "Task 'my-task' does not contain a bundle reference"
+	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
 	lib.assert_equal(deny, {{
 		"code": "disallowed_task_reference",
 		"msg": expected_msg,
@@ -34,7 +34,7 @@ test_bundle_not_exists_empty_string {
 		"ref": {"name": "good-task", "bundle": image},
 	})
 
-	expected_msg := sprintf("Task '%s' uses an empty bundle image reference", [name])
+	expected_msg := sprintf("Pipeline task '%s' uses an empty bundle image reference", [name])
 	lib.assert_equal(deny, {{
 		"code": "empty_task_bundle_reference",
 		"msg": expected_msg,
@@ -70,16 +70,6 @@ test_acceptable_bundle_up_to_date {
 		with data["task-bundles"] as task_bundles
 }
 
-# All good when the most recent bundle is used when streams are used.
-test_acceptable_bundle_up_to_date_with_streams {
-	attestations := mock_attestation(["reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2@sha256:abc"])
-	lib.assert_empty(warn) with input.attestations as attestations
-		with data["task-bundles"] as task_bundles
-
-	lib.assert_empty(deny) with input.attestations as attestations
-		with data["task-bundles"] as task_bundles
-}
-
 # Warn about out of date bundles that are still acceptable.
 test_acceptable_bundle_out_of_date_past {
 	attestations := mock_attestation(["reg.com/repo@sha256:bcd", "reg.com/repo@sha256:cde"])
@@ -88,12 +78,12 @@ test_acceptable_bundle_out_of_date_past {
 		{
 			"code": "out_of_date_task_bundle",
 			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Task 'task-run-0' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
+			"msg": "Pipeline task 'task-run-0' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
 		},
 		{
 			"code": "out_of_date_task_bundle",
 			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Task 'task-run-1' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
+			"msg": "Pipeline task 'task-run-1' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
 		},
 	}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
@@ -102,33 +92,7 @@ test_acceptable_bundle_out_of_date_past {
 		with data["task-bundles"] as task_bundles
 }
 
-# Warn about out of date bundles that are still acceptable when streams are used.
-test_acceptable_bundle_out_of_date_past_with_streams {
-	# Verify streams are honored
-	attestations := mock_attestation([
-		"reg.com/repo:b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2@sha256:bcd",
-		"reg.com/repo:120dda49a6cc3b89516b491e19fe1f3a07f1427f-2@sha256:cde",
-	])
-
-	lib.assert_equal(warn, {
-		{
-			"code": "out_of_date_task_bundle",
-			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Task 'task-run-0' uses an out of date task bundle 'reg.com/repo:b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2@sha256:bcd'",
-		},
-		{
-			"code": "out_of_date_task_bundle",
-			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": "Task 'task-run-1' uses an out of date task bundle 'reg.com/repo:120dda49a6cc3b89516b491e19fe1f3a07f1427f-2@sha256:cde'",
-		},
-	}) with input.attestations as attestations
-		with data["task-bundles"] as task_bundles
-
-	lib.assert_empty(deny) with input.attestations as attestations
-		with data["task-bundles"] as task_bundles
-}
-
-# Warn about bundles that are no longer active.
+# Deny bundles that are no longer active.
 test_acceptable_bundle_expired {
 	attestations := mock_attestation(["reg.com/repo@sha256:def"])
 	lib.assert_empty(warn) with input.attestations as attestations
@@ -137,60 +101,9 @@ test_acceptable_bundle_expired {
 	lib.assert_equal(deny, {{
 		"code": "unacceptable_task_bundle",
 		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "Task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
+		"msg": "Pipeline task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.attestations as attestations
 		with data["task-bundles"] as task_bundles
-}
-
-# Warn about bundles that are no longer active when streams are used.
-test_acceptable_bundle_expired_with_streams {
-	attestations := mock_attestation(["reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-1@sha256:def"])
-	lib.assert_empty(warn) with input.attestations as attestations
-		with data["task-bundles"] as task_bundles
-
-	lib.assert_equal(deny, {{
-		"code": "unacceptable_task_bundle",
-		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "Task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-1@sha256:def'",
-	}}) with input.attestations as attestations
-		with data["task-bundles"] as task_bundles
-}
-
-test_stream {
-	lib.assert_equal(_stream(""), "default")
-	lib.assert_equal(_stream("spam"), "default")
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5"), "default")
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-9-9"), "default")
-	lib.assert_equal(_stream("spam-903d49a833d22f359bce3d67b15b006e1197bae5-2"), "default")
-
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-2"), "2")
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-999"), "999")
-}
-
-test_tag_by_digest {
-	refs := [
-		{
-			"digest": "sha256:abc",
-			"tag": "ignore-me",
-		},
-		{
-			"digest": "sha256:bcd",
-			"tag": "the-tag",
-		},
-		{
-			"digest": "sha256:bcd",
-			"tag": "repeat-digest",
-		},
-	]
-
-	# The first match is found
-	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:bcd", "tag": ""}), "the-tag")
-
-	# Skip search if tag is already provided
-	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:bcd", "tag": "tag-known"}), "tag-known")
-
-	# No match found
-	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:cde", "tag": ""}), "")
 }
 
 mock_attestation(bundles) = a {
@@ -213,43 +126,27 @@ mock_attestation(bundles) = a {
 
 task_bundles = {"reg.com/repo": [
 	{
-		"digest": "sha256:012", # Ignore
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-1",
+		# Latest bundle, allowed
+		"digest": "sha256:abc",
+		"tag": "",
 		"effective_on": "2262-04-11T00:00:00Z",
 	},
 	{
-		"digest": "sha256:abc", # Allow
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-2",
-		"effective_on": "2262-04-11T00:00:00Z",
-	},
-	{
-		"digest": "sha256:123", # Ignore
-		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-1",
+		# Recent bundle effective in the future, allowed but warn to upgrade
+		"digest": "sha256:bcd",
+		"tag": "",
 		"effective_on": "2262-03-11T00:00:00Z",
 	},
 	{
-		"digest": "sha256:bcd", # Warn
-		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2",
-		"effective_on": "2262-03-11T00:00:00Z",
-	},
-	{
-		"digest": "sha256:234", # Ignore
-		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f-1",
+		# Recent bundle effective in the past, allowed but warn to upgrade
+		"digest": "sha256:cde",
+		"tag": "",
 		"effective_on": "2022-02-01T00:00:00Z",
 	},
 	{
-		"digest": "sha256:cde", # Warn
-		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f-2",
-		"effective_on": "2022-02-01T00:00:00Z",
-	},
-	{
-		"digest": "sha256:345", # Ignore
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-1",
-		"effective_on": "2021-01-01T00:00:00Z",
-	},
-	{
-		"digest": "sha256:def", # Warn
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-2",
+		# Old bundle, denied
+		"digest": "sha256:def",
+		"tag": "",
 		"effective_on": "2021-01-01T00:00:00Z",
 	},
 ]}

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -44,9 +44,29 @@ test_bundle_not_exists_empty_string {
 	lib.assert_empty(warn) with input.attestations as d
 }
 
+test_bundle_unpinned {
+	name := "my-task"
+	image := "reg.com/repo:latest"
+	d := mock_data({
+		"name": name,
+		"ref": {
+			"name": "good-task",
+			"bundle": image,
+		},
+	})
+
+	lib.assert_empty(deny) with input.attestations as d
+	expected_msg := sprintf("Pipeline task '%s' uses an unpinned task bundle reference '%s'", [name, image])
+	lib.assert_equal(warn, {{
+		"code": "unpinned_task_bundle",
+		"msg": expected_msg,
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.attestations as d
+}
+
 test_bundle_reference_valid {
 	name := "my-task"
-	image := "quay.io/redhat-appstudio/hacbs-templates-bundle:latest"
+	image := "quay.io/redhat-appstudio/hacbs-templates-bundle:latest@sha256:abc"
 	d := mock_data({
 		"name": name,
 		"ref": {


### PR DESCRIPTION

```
Add task bundle rules for pipeline package

Refactored the existing task bundle rules for release package as to
minimize code duplication.
```

```
Add warning when unpinned tekton bundle is used
```

https://issues.redhat.com/browse/HACBS-984
