### PR TITLE
Provide "raw" data file in docs

### DIFF
--- a/antora/docs/modules/ROOT/nav.adoc
+++ b/antora/docs/modules/ROOT/nav.adoc
@@ -3,3 +3,4 @@
 * xref:pipeline_policy.adoc[Pipeline Policy]
 * xref:acceptable_bundles.adoc[Acceptable Bundles]
 * xref:authoring.adoc[Policy Authoring]
+* xref:raw_data.adoc[Raw Data]

--- a/antora/docs/modules/ROOT/templates/raw_data.hbs
+++ b/antora/docs/modules/ROOT/templates/raw_data.hbs
@@ -1,0 +1,7 @@
+= Raw data
+
+:numbered:
+
+If you need it you can access this information in JSON format.
+
+* link:data.json[Raw data (JSON)]

--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -171,7 +171,7 @@ const helpers = {
         // other popular container registries.
         const repoUrl = hbsHelpers.repoUrl(k)
         const digestUrl = `${repoUrl}/manifest/${d.digest}`
-        const tagUrl = `$(repoUrl)?tab=tags&tag=${d.tag}`
+        const tagUrl = `${repoUrl}?tab=tags&tag=${d.tag}`
         const shortDigest = d.digest.split(":")[1].slice(0,12)
 
         return {


### PR DESCRIPTION
The idea is that the UI team could use that to expose the rules and their metadata to users via the web UI.

Do some extra work so that the package information is available in a more convenient place.