### PR TITLE
Check provenance of test and java TaskRun results

### DIFF
--- a/policy/lib/bundles.rego
+++ b/policy/lib/bundles.rego
@@ -57,6 +57,18 @@ unacceptable_task_bundle(tasks) = matches {
 	}
 }
 
+# Returns true if the provided bundle reference is acceptable
+is_acceptable(bundle_ref) {
+	ref := image.parse(bundle_ref)
+	collection := _collection(ref)
+	matches := [r |
+		r := collection[_]
+		is_equal(r, ref)
+	]
+
+	count(matches) > 0
+}
+
 # Returns whether or not the ref matches the digest of the record.
 is_equal(record, ref) = match {
 	ref.digest != ""

--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -2,6 +2,16 @@ package lib.bundles
 
 import data.lib
 
+# used as reference bundle data in tests
+bundle_data := {"registry.img/acceptable": [{
+	"digest": "sha256:digest",
+	"tag": "",
+	"effective_on": "2000-01-01T00:00:00Z",
+}]}
+
+# used as reference bundle data in tests
+acceptable_bundle_ref := "registry.img/acceptable@sha256:digest"
+
 test_disallowed_task_reference {
 	tasks := [
 		{"name": "my-task-1", "taskRef": {}},
@@ -236,3 +246,11 @@ task_bundles = {"reg.com/repo": [
 		"effective_on": "2021-01-01T00:00:00Z",
 	},
 ]}
+
+test_acceptable_bundle_is_acceptable {
+	is_acceptable(acceptable_bundle_ref) with data["task-bundles"] as bundle_data
+}
+
+test_unacceptable_bundle_is_unacceptable {
+	not is_acceptable("registry.img/unacceptable@sha256:digest") with data["task-bundles"] as bundle_data
+}

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -1,13 +1,22 @@
 package policy.release.java
 
 import data.lib
+import data.lib.bundles
 
 test_all_good {
-	attestations := [lib.att_mock_helper(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42}, "java-task-1")]
-	lib.assert_empty(deny) with input.attestations as attestations
+	attestations := [lib.att_mock_helper_ref(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42}, "java-task-1", bundles.acceptable_bundle_ref)]
+	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as attestations
 }
 
 test_has_foreign {
-	attestations := [lib.att_mock_helper(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42, "central": 1}, "java-task-1")]
-	lib.assert_equal(deny, {{"code": "java_foreign_dependencies", "effective_on": "2022-01-01T00:00:00Z", "msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'"}}) with input.attestations as attestations
+	attestations := [lib.att_mock_helper_ref(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42, "central": 1}, "java-task-1", bundles.acceptable_bundle_ref)]
+	lib.assert_equal(deny, {{"code": "java_foreign_dependencies", "effective_on": "2022-01-01T00:00:00Z", "msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'"}}) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as attestations
+}
+
+test_unacceptable_bundle {
+	attestations := [lib.att_mock_helper_ref(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42}, "java-task-1", "registry.img/unacceptable@sha256:digest")]
+	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as attestations
 }

--- a/policy/release/main_test.rego
+++ b/policy/release/main_test.rego
@@ -1,6 +1,7 @@
 package release.main
 
 import data.lib
+import data.lib.bundles
 
 # Todo: Some of this might be better placed in policy/lib/main_denies_test
 
@@ -67,7 +68,9 @@ test_test_can_be_skipped {
 }
 
 test_test_succeeds {
-	lib.assert_empty(deny) with input.attestations as [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "mytask")] with data.config.policy as nonblocking_except({"test"})
+	lib.assert_empty(deny) with input.attestations as [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "mytask", bundles.acceptable_bundle_ref)]
+		with data["task-bundles"] as bundles.bundle_data
+		with data.config.policy as nonblocking_except({"test"})
 }
 
 test_test_fails {
@@ -75,7 +78,9 @@ test_test_fails {
 		"code": "test_result_failures",
 		"msg": "The following tests did not complete successfully: test1",
 		"effective_on": "2022-01-01T00:00:00Z",
-	}}) with input.attestations as [lib.att_mock_helper(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "test1")] with data.config.policy as nonblocking_except({"test"})
+	}}) with input.attestations as [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "test1", bundles.acceptable_bundle_ref)]
+		with data["task-bundles"] as bundles.bundle_data
+		with data.config.policy as nonblocking_except({"test"})
 }
 
 test_policy_ignored_when_not_yet_effective {

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -1,6 +1,7 @@
 package policy.release.tasks
 
 import data.lib
+import data.lib.bundles
 
 test_no_tasks_present {
 	expected := {{
@@ -9,62 +10,91 @@ test_no_tasks_present {
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}
 
-	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": []},
-	}}]
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": []},
+		}}]
 }
 
 test_empty_task_attested {
 	expected := missing_tasks_error(all_required_tasks)
 
-	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": [{}]},
-	}}]
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": [{}]},
+		}}]
 }
 
 test_all_required_tasks_not_present {
 	expected := missing_tasks_error(all_required_tasks)
 
-	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": [{"ref": {"name": "custom", "kind": "Task"}}]},
-	}}]
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": [{"ref": {"name": "custom", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}}]},
+		}}]
 }
 
 test_all_but_one_required_task_not_present {
 	expected := missing_tasks_error(all_required_tasks - {"sanity-inspect-image"})
 
-	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": [{"ref": {"name": "sanity-inspect-image", "kind": "Task"}}]},
-	}}]
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": [{"ref": {"name": "sanity-inspect-image", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}}]},
+		}}]
 }
 
 test_several_tasks_not_present {
 	expected := missing_tasks_error(all_required_tasks - {"sanity-inspect-image", "clamav-scan", "add-sbom-and-push"})
 
-	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
-		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": [
-			{"ref": {"name": "sanity-inspect-image", "kind": "Task"}},
-			{"ref": {"name": "clamav-scan", "kind": "Task"}},
-			{"ref": {"name": "add-sbom-and-push", "kind": "Task"}},
-		]},
-	}}]
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": [
+				{"ref": {"name": "sanity-inspect-image", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{"ref": {"name": "clamav-scan", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{"ref": {"name": "add-sbom-and-push", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+			]},
+		}}]
 }
 
 test_tricks {
 	expected := missing_tasks_error(all_required_tasks)
 
-	lib.assert_equal(deny, expected) with input.attestations as [{"predicate": {
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": [
+				{"name": "sanity-inspect-image"},
+				{"ref": {"name": "sanity-inspect-image", "kind": "NotTask", "bundle": bundles.acceptable_bundle_ref}},
+			]},
+		}}]
+}
+
+test_task_present_from_unacceptable_bundle {
+	names := all_required_tasks - {"sanity-inspect-image"}
+
+	task_from_unacceptable := [{"ref": {"name": "sanity-inspect-image", "kind": "Task", "bundle": "registry.img/unacceptable@sha256:digest"}}]
+
+	tasks := array.concat(
+		[t |
+			name := names[_]
+			t := {"ref": {"name": name, "kind": "Task", "bundle": bundles.acceptable_bundle_ref}}
+		],
+		task_from_unacceptable,
+	)
+
+	attestations := [{"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
-		"buildConfig": {"tasks": [
-			{"name": "sanity-inspect-image"},
-			{"ref": {"name": "sanity-inspect-image", "kind": "NotTask"}},
-		]},
+		"buildConfig": {"tasks": tasks},
 	}}]
+
+	expected := missing_tasks_error({"sanity-inspect-image"})
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as attestations
 }
 
 missing_tasks_error(missing) = error {

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -5,6 +5,10 @@
 #   to a set of tests and that those tests all passed. This package
 #   includes a set of rules to verify that.
 #
+#   The rest result data must be reported by a Tekton Task that has been loaded
+#   from an acceptable Tekton Bundle.
+#   See xref:release_policy.adoc#attestation_task_bundle_package[Task bundle checks].
+#
 #   TODO: Document how you can skip the requirement for individual
 #   tests if needed using the `non_blocking_rule` configuration.
 #
@@ -24,7 +28,9 @@ import future.keywords.in
 #   failure_msg: No test data found
 #
 deny[result] {
-	count(lib.results_from_tests) == 0
+	results := lib.results_from_tests
+	count(results) == 0 # there are none at all
+
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -181,7 +181,7 @@ test_unacceptable_bundle_results {
 		"code": "test_data_missing",
 		"msg": "No test data found",
 		"effective_on": "2022-01-01T00:00:00Z",
-	}}) with input.attestations as [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "task1", "registry.img/unaccepable@sha256:digest")]
+	}}) with input.attestations as [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "task1", "registry.img/unacceptable@sha256:digest")]
 		with data["task-bundles"] as bundles.bundle_data
 		with data.config.policy as {"non_blocking_checks": []}
 }


### PR DESCRIPTION
With this the `TaskRun` results considered by the `test` and `java` policy rules need to be from a `TaskRun` loaded from via a Tekton Bundle, i.e. not defined on the cluster or inline in a `PipelineRun`, and the image reference from which the `Task` was loaded needs to be one from the list of accepted bundles (`acceptable_tekton_bundles.yml`).

The caveat with the `java` policy rules is that there is no policy denial resulting from omission of the result. This is relevant here because the omission of the result could be due to the `TaskRun` result resulting from an inline, cluster or unacceptable bundle.

Ref. https://issues.redhat.com/browse/HACBS-995