### PR TITLE
Required tasks policy with invocation parameters

### DIFF
--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -18,7 +18,7 @@ test_no_tasks_present {
 }
 
 test_empty_task_attested {
-	expected := missing_tasks_error(all_required_tasks)
+	expected := _missing_tasks_error(all_required_tasks)
 
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as [{"predicate": {
@@ -28,7 +28,7 @@ test_empty_task_attested {
 }
 
 test_all_required_tasks_not_present {
-	expected := missing_tasks_error(all_required_tasks)
+	expected := _missing_tasks_error(all_required_tasks)
 
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as [{"predicate": {
@@ -38,7 +38,7 @@ test_all_required_tasks_not_present {
 }
 
 test_all_but_one_required_task_not_present {
-	expected := missing_tasks_error(all_required_tasks - {"sanity-inspect-image"})
+	expected := _missing_tasks_error(all_required_tasks - {"sanity-inspect-image"})
 
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as [{"predicate": {
@@ -48,7 +48,7 @@ test_all_but_one_required_task_not_present {
 }
 
 test_several_tasks_not_present {
-	expected := missing_tasks_error(all_required_tasks - {"sanity-inspect-image", "clamav-scan", "add-sbom-and-push"})
+	expected := _missing_tasks_error(all_required_tasks - {"sanity-inspect-image", "clamav-scan", "add-sbom-and-push"})
 
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as [{"predicate": {
@@ -62,7 +62,7 @@ test_several_tasks_not_present {
 }
 
 test_tricks {
-	expected := missing_tasks_error(all_required_tasks)
+	expected := _missing_tasks_error(all_required_tasks)
 
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as [{"predicate": {
@@ -75,29 +75,66 @@ test_tricks {
 }
 
 test_task_present_from_unacceptable_bundle {
-	names := all_required_tasks - {"sanity-inspect-image"}
-
 	task_from_unacceptable := [{"ref": {"name": "sanity-inspect-image", "kind": "Task", "bundle": "registry.img/unacceptable@sha256:digest"}}]
 
-	tasks := array.concat(
-		[t |
-			name := names[_]
-			t := {"ref": {"name": name, "kind": "Task", "bundle": bundles.acceptable_bundle_ref}}
-		],
-		task_from_unacceptable,
-	)
+	attestations := _attestations_with_tasks(all_required_tasks - {"sanity-inspect-image"}, task_from_unacceptable)
+
+	expected := _missing_tasks_error({"sanity-inspect-image"})
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as attestations
+}
+
+test_parameterized {
+	with_wrong_parameter := [
+		{
+			"ref": {
+				"name": "sanity-label-check",
+				"kind": "Task",
+				"bundle": bundles.acceptable_bundle_ref,
+			},
+			"invocation": {"parameters": {"POLICY_NAMESPACE": "something-else"}},
+		},
+		{
+			"ref": {
+				"name": "sanity-label-check",
+				"kind": "Task",
+				"bundle": bundles.acceptable_bundle_ref,
+			},
+			"invocation": {"parameters": {"POLICY_NAMESPACE": "optional_checks"}},
+		},
+	]
+
+	attestations := _attestations_with_tasks(all_required_tasks - {"sanity-label-check[POLICY_NAMESPACE=required_checks]", "sanity-label-check[POLICY_NAMESPACE=optional_checks]"}, with_wrong_parameter)
+
+	expected := _missing_tasks_error({"sanity-label-check[POLICY_NAMESPACE=required_checks]"})
+	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as attestations
+}
+
+_attestations_with_tasks(names, add_tasks) = attestations {
+	tasks := array.concat([t | t := _task(names[_])], add_tasks)
 
 	attestations := [{"predicate": {
 		"buildType": lib.pipelinerun_att_build_types[0],
 		"buildConfig": {"tasks": tasks},
 	}}]
-
-	expected := missing_tasks_error({"sanity-inspect-image"})
-	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
-		with input.attestations as attestations
 }
 
-missing_tasks_error(missing) = error {
+_task(name) = task {
+	parts := regex.split("[\\[\\]=]", name)
+	parts[1]
+	task_name := parts[0]
+
+	task := {"ref": {"name": task_name, "kind": "Task", "bundle": bundles.acceptable_bundle_ref}, "invocation": {"parameters": {parts[1]: parts[2]}}}
+}
+
+_task(name) = task {
+	parts := regex.split("[\\[\\]=]", name)
+	not parts[1]
+	task := {"ref": {"name": name, "kind": "Task", "bundle": bundles.acceptable_bundle_ref}}
+}
+
+_missing_tasks_error(missing) = error {
 	error := {{
 		"code": "tasks_required",
 		"msg": sprintf("Required task(s) '%s' not found in the PipelineRun attestation", [concat("', '", missing)]),


### PR DESCRIPTION
This is built upon #139, so review that first.

The `sanity-label-check` Task can be parameterized with `POLICY_NAMESPACE` parameter, which can have values `required_checks` and `optional_checks`. When the task is run in the pipeline it is given then name `sanity-label-check` and `sanity-optional-label-check`. Note this is the given name for a `Task` within the `PipelineRun`. We assert the name of the referenced task from the Task Bundle, which in both cases is `sanity-label-check`.

So to distinguish between this two cases in addition to requiring a task by name, this allows to require a task by a parameter and value.

So the required task list now can include:
 - `sanity-label-check[POLICY_NAMESPACE=required_checks]`
 - `sanity-label-check[POLICY_NAMESPACE=optional_checks]`

This resolves the first part of HACBS-1166.

Ref. https://issues.redhat.com/browse/HACBS-1166

[1] https://issues.redhat.com/browse/HACBS-995