### PR TITLE
Remove unknown required task add-sbom-and-push

### DIFF
--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -17,7 +17,6 @@
 #   tasks_required:
 #     rule_data:
 #       required_task_refs:
-#       - add-sbom-and-push
 #       - clamav-scan
 #       - deprecated-image-check
 #       - get-clair-scan


### PR DESCRIPTION
The task named add-sbom-and-push does not exist. Instead, the sbom work is done as a step of the corresponding build task, e.g. buildah.

Checking that the SBOM was created will be done in the future as part of https://issues.redhat.com/browse/HACBS-1230

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>