### PR TITLE
Use node version from package.json and cache

### DIFF
--- a/.github/workflows/release-antora-extension.yaml
+++ b/.github/workflows/release-antora-extension.yaml
@@ -20,7 +20,8 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        cache: 'npm'
+        node-version-file: 'antora/ec-policies-antora-extension/package.json'
 
     - name: Publish npm package
       run: make npm-publish

--- a/antora/ec-policies-antora-extension/package.json
+++ b/antora/ec-policies-antora-extension/package.json
@@ -17,5 +17,8 @@
   "homepage": "https://github.com/hacbs-contract/ec-policies/tree/main/antora/ec-policies-antora-extension#readme",
   "dependencies": {
     "@zregvart/opa-inspect": "latest"
+  },
+  "engines": {
+    "node": "18"
   }
 }


### PR DESCRIPTION
Caching makes for faster builds, having the engine in the package.json makes it easier to consume and configure the build.