### PR TITLE
Support a list of authorizations

### DIFF
--- a/policy/release/authorization.rego
+++ b/policy/release/authorization.rego
@@ -36,7 +36,6 @@ deny[result] {
 	count(data.authorization) > 0
 	att := lib.pipelinerun_attestations[_]
 	material := att.predicate.materials[_]
-	auths := data.authorization[_]
 	not sha_in_auth(material.digest.sha1, data.authorization)
 	result := lib.result_helper(rego.metadata.chain(), [material.digest.sha1])
 }

--- a/policy/release/authorization.rego
+++ b/policy/release/authorization.rego
@@ -20,7 +20,7 @@ import data.lib
 #   failure_msg: Commit does not contain authorization
 deny[result] {
 	data.authorization
-	not data.authorization.authorizers
+	count(data.authorization) == 0
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 
@@ -30,13 +30,15 @@ deny[result] {
 #   Enterprise Contract verifies if an authorized commit was used as the source of a build
 # custom:
 #   short_name: disallowed_commit_does_not_match
-#   failure_msg: Commit %s does not match authorized commit %s
+#   failure_msg: Commit %s does not match authorized commits
 deny[result] {
 	data.authorization
+	count(data.authorization) > 0
 	att := lib.pipelinerun_attestations[_]
 	material := att.predicate.materials[_]
-	data.authorization.changeId != material.digest.sha1
-	result := lib.result_helper(rego.metadata.chain(), [material.digest.sha1, data.authorization.changeId])
+	auths := data.authorization[_]
+	not sha_in_auth(material.digest.sha1, data.authorization)
+	result := lib.result_helper(rego.metadata.chain(), [material.digest.sha1])
 }
 
 # METADATA
@@ -45,11 +47,22 @@ deny[result] {
 #   Enterprise Contract verifies if an authorized repo url was used to build an image
 # custom:
 #   short_name: disallowed_repo_url_does_not_match
-#   failure_msg: Repo url %s does not match authorized repo url %s
+#   failure_msg: Repo url %s does not match authorized repo urls
 deny[result] {
 	data.authorization
+	count(data.authorization) > 0
 	att := lib.pipelinerun_attestations[_]
 	material := att.predicate.materials[_]
-	data.authorization.repository != material.uri
-	result := lib.result_helper(rego.metadata.chain(), [material.uri, data.authorization.repository])
+	not repo_in_auth(material.uri, data.authorization)
+	result := lib.result_helper(rego.metadata.chain(), [material.uri])
+}
+
+sha_in_auth(changeid, authorizations) {
+	auths := authorizations[_]
+	auths.changeId == changeid
+}
+
+repo_in_auth(repo, authorizations) {
+	auths := authorizations[_]
+	auths.repoUrl == repo
 }

--- a/policy/release/authorization.rego
+++ b/policy/release/authorization.rego
@@ -17,7 +17,7 @@ import data.lib
 #   Enterprise Contract verifies if the build was authorized
 # custom:
 #   short_name: disallowed_no_authorization
-#   failure_msg: Commit does not contain authorization
+#   failure_msg: No authorization data found
 deny[result] {
 	data.authorization
 	count(data.authorization) == 0
@@ -30,14 +30,14 @@ deny[result] {
 #   Enterprise Contract verifies if an authorized commit was used as the source of a build
 # custom:
 #   short_name: disallowed_commit_does_not_match
-#   failure_msg: Commit %s does not match authorized commits
+#   failure_msg: Commit %s does not match authorized commit %s
 deny[result] {
 	data.authorization
 	count(data.authorization) > 0
 	att := lib.pipelinerun_attestations[_]
 	material := att.predicate.materials[_]
 	not sha_in_auth(material.digest.sha1, data.authorization)
-	result := lib.result_helper(rego.metadata.chain(), [material.digest.sha1])
+	result := lib.result_helper(rego.metadata.chain(), [material.digest.sha1, data.authorization[_].changeId])
 }
 
 # METADATA
@@ -46,14 +46,14 @@ deny[result] {
 #   Enterprise Contract verifies if an authorized repo url was used to build an image
 # custom:
 #   short_name: disallowed_repo_url_does_not_match
-#   failure_msg: Repo url %s does not match authorized repo urls
+#   failure_msg: Repo url %s does not match authorized repo url %s
 deny[result] {
 	data.authorization
 	count(data.authorization) > 0
 	att := lib.pipelinerun_attestations[_]
 	material := att.predicate.materials[_]
 	not repo_in_auth(material.uri, data.authorization)
-	result := lib.result_helper(rego.metadata.chain(), [material.uri])
+	result := lib.result_helper(rego.metadata.chain(), [material.uri, data.authorization[_].repoUrl])
 }
 
 sha_in_auth(changeid, authorizations) {

--- a/policy/release/authorization_test.rego
+++ b/policy/release/authorization_test.rego
@@ -15,7 +15,7 @@ git_repo := "https://github.com/hacbs-contract/ec-policies.git"
 commit_sha := "1234"
 
 test_no_authorization {
-	expected_msg := "Commit does not contain authorization"
+	expected_msg := "No authorization data found"
 	lib.assert_equal(deny, {{
 		"code": "disallowed_no_authorization",
 		"msg": expected_msg,
@@ -24,7 +24,7 @@ test_no_authorization {
 }
 
 test_commit_does_not_match {
-	expected_msg := sprintf("Commit %s does not match authorized commits", [commit_sha])
+	expected_msg := sprintf("Commit %s does not match authorized commit %s", [commit_sha, "2468"])
 	lib.assert_equal(deny, {{
 		"code": "disallowed_commit_does_not_match",
 		"msg": expected_msg,
@@ -33,7 +33,7 @@ test_commit_does_not_match {
 }
 
 test_repo_does_not_match {
-	expected_msg := sprintf("Repo url %s does not match authorized repo urls", [git_repo])
+	expected_msg := sprintf("Repo url %s does not match authorized repo url %s", [git_repo, "https://github.com/hacbs-contract/authorized.git"])
 	lib.assert_equal(deny, {{
 		"code": "disallowed_repo_url_does_not_match",
 		"msg": expected_msg,

--- a/policy/release/authorization_test.rego
+++ b/policy/release/authorization_test.rego
@@ -3,7 +3,7 @@ package policy.release.authorization
 import data.lib
 
 mock_data(changeId, repo, authorizers) = d {
-	d := [{"repoUrl":repo,"changeId":changeId,"authorizers":[authorizers]}]
+	d := [{"repoUrl": repo, "changeId": changeId, "authorizers": [authorizers]}]
 }
 
 mock_empty_data = d {

--- a/policy/release/authorization_test.rego
+++ b/policy/release/authorization_test.rego
@@ -3,11 +3,11 @@ package policy.release.authorization
 import data.lib
 
 mock_data(changeId, repo, authorizers) = d {
-	d := {"changeId": changeId, "repository": repo, "authorizers": [authorizers]}
+	d := [{"repoUrl":repo,"changeId":changeId,"authorizers":[authorizers]}]
 }
 
 mock_empty_data = d {
-	d := {"authorization": {}}
+	d := []
 }
 
 git_repo := "https://github.com/hacbs-contract/ec-policies.git"
@@ -24,7 +24,7 @@ test_no_authorization {
 }
 
 test_commit_does_not_match {
-	expected_msg := sprintf("Commit %s does not match authorized commit %s", [commit_sha, "2468"])
+	expected_msg := sprintf("Commit %s does not match authorized commits", [commit_sha])
 	lib.assert_equal(deny, {{
 		"code": "disallowed_commit_does_not_match",
 		"msg": expected_msg,
@@ -33,7 +33,7 @@ test_commit_does_not_match {
 }
 
 test_repo_does_not_match {
-	expected_msg := sprintf("Repo url %s does not match authorized repo url %s", [git_repo, "https://github.com/hacbs-contract/authorized.git"])
+	expected_msg := sprintf("Repo url %s does not match authorized repo urls", [git_repo])
 	lib.assert_equal(deny, {{
 		"code": "disallowed_repo_url_does_not_match",
 		"msg": expected_msg,


### PR DESCRIPTION
This updates the authorizations to support a list of repositories and changeIds. Each repo and changeId is compared against the repository and git sha in the attestation.