### PR TITLE
Don't require `sast-go` task

### DIFF
--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -23,7 +23,6 @@
 #       - sanity-inspect-image
 #       - sanity-label-check[POLICY_NAMESPACE=required_checks]
 #       - sanity-label-check[POLICY_NAMESPACE=optional_checks]
-#       - sast-go
 #
 package policy.release.tasks
 


### PR DESCRIPTION
See https://github.com/redhat-appstudio/build-definitions/pull/216