### PR TITLE
Try new styling format

### DIFF
--- a/policy/lib/annotations.rego
+++ b/policy/lib/annotations.rego
@@ -1,0 +1,5 @@
+package lib
+
+rule_data(metadata, name) = value {
+	value := metadata.custom.rule_data[name]
+}

--- a/policy/lib/annotations_test.rego
+++ b/policy/lib/annotations_test.rego
@@ -1,0 +1,15 @@
+package lib
+
+import data.lib
+
+test_rule_data {
+	metadata := {"custom": {"rule_data": {"breakfast": [
+		"spam",
+		"bacon",
+		"eggs",
+	]}}}
+	expected_breakfast := ["spam", "bacon", "eggs"]
+	lib.assert_equal(expected_breakfast, rule_data(metadata, "breakfast"))
+
+	not rule_data(metadata, "lunch")
+}

--- a/policy/release/attestation_type.rego
+++ b/policy/release/attestation_type.rego
@@ -5,6 +5,10 @@
 #
 package policy.release.attestation_type
 
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
 import data.lib
 
 # METADATA
@@ -19,9 +23,10 @@ import data.lib
 #     known_attestation_types:
 #     - https://in-toto.io/Statement/v0.1
 #
-deny[result] {
-	att := lib.pipelinerun_attestations[_]
+deny contains result if {
+	some att in lib.pipelinerun_attestations
+	known_attestation_types := lib.rule_data(rego.metadata.rule(), "known_attestation_types")
 	att_type := att._type
-	not lib.included_in(att_type, rego.metadata.rule().custom.rule_data.known_attestation_types)
+	not att_type in known_attestation_types
 	result := lib.result_helper(rego.metadata.chain(), [att_type])
 }


### PR DESCRIPTION
Modify the attestion_type policy rule to better conform with the rego style guide suggested in https://github.com/StyraInc/rego-style-guide

Notable chagnes:
    * Use the newer "container ... if" syntax
    * Use help function to extract value from annotation
    * Use the newer "some ... in" syntax

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>