### PR TITLE
Add support for different JSON types of results

### DIFF
--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -44,8 +44,5 @@ _java_component_sources contains name if {
 	some result in lib.results_named(lib.java_sbom_component_count_result_name)
 	bundle := result[lib.key_bundle]
 	bundles.is_acceptable(bundle)
-	some name, _ in result
-
-	# Exclude metadata attributes
-	not name in {lib.key_task_name, lib.key_bundle}
+	some name, _ in result[lib.key_value]
 }

--- a/policy/release/lib/attestations.rego
+++ b/policy/release/lib/attestations.rego
@@ -23,6 +23,8 @@ key_task_name := "__task_name"
 
 key_bundle := "__bundle_name"
 
+key_value := "__value"
+
 # These are the ones we're interested in
 pipelinerun_attestations := [att |
 	att := input.attestations[_]
@@ -41,9 +43,11 @@ tasks_from_pipelinerun := [task |
 ]
 
 # All results from the attested PipelineRun with the provided name. Results are
-# expected to contain a JSON value. The JSON value will be augmented with a key
-# "__task_name" that will hold the name of the TaskRun where the named result
-# was found.
+# expected to contain a JSON value. The return object contains the following
+# keys:
+#   __task_name: name of the task in which the result appears.
+#   __bundle_name: Tekton bundle image reference for the corresponding task.
+#   __value: unmarshalled task result.
 results_named(name) = results {
 	results := [r |
 		task := tasks_from_pipelinerun[_]
@@ -53,7 +57,7 @@ results_named(name) = results {
 
 		# Inject the task data, currently task name and task bundle image
 		# reference so we can show it in failure messages
-		r := object.union(result_map, task_data(task))
+		r := object.union({key_value: result_map}, task_data(task))
 	]
 }
 

--- a/policy/release/lib/attestations_test.rego
+++ b/policy/release/lib/attestations_test.rego
@@ -143,7 +143,11 @@ test_att_mock_helper_ref {
 }
 
 test_results_from_tests {
-	expected := {"result": "SUCCESS", "foo": "bar", lib.key_task_name: "mytask", lib.key_bundle: "registry.img/acceptable@sha256:digest"}
+	expected := {
+		lib.key_value: {"result": "SUCCESS", "foo": "bar"},
+		lib.key_task_name: "mytask",
+		lib.key_bundle: "registry.img/acceptable@sha256:digest",
+	}
 	assert_equal([expected], results_from_tests) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as [att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SUCCESS", "foo": "bar"}, "mytask", bundles.acceptable_bundle_ref)]
 }

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -44,7 +44,7 @@ deny[result] {
 #   failure_msg: Found tests without results
 #
 deny[result] {
-	with_results := [result | result := lib.results_from_tests[_].result]
+	with_results := [result | result := lib.results_from_tests[_][lib.key_value].result]
 	count(with_results) != count(lib.results_from_tests)
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
@@ -66,9 +66,10 @@ deny[result] {
 #
 deny[result] {
 	all_unsupported := [u |
-		test := lib.results_from_tests[_]
+		result := lib.results_from_tests[_]
+		test := result[lib.key_value]
 		not test.result in lib.rule_data(rego.metadata.rule(), "supported_results")
-		u := {"task": test.__task_name, "result": test.result}
+		u := {"task": result[lib.key_task_name], "result": test.result}
 	]
 
 	count(all_unsupported) > 0
@@ -129,8 +130,9 @@ resulted_in(results) = filtered_by_result {
 	# Collect all tests that have resulted with one of the given
 	# results and convert their name to "test:<name>" format
 	filtered_by_result := {r |
-		test := lib.results_from_tests[_]
+		result := lib.results_from_tests[_]
+		test := result[lib.key_value]
 		test.result in results
-		r := sprintf("test:%s", [test.__task_name])
+		r := sprintf("test:%s", [result[lib.key_task_name]])
 	}
 }


### PR DESCRIPTION
Task results are not required to be a JSON object. This commit changes the data returned by `results_named` to better represent this.

This work is required for https://issues.redhat.com/browse/HACBS-1291

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>