### PR TITLE
Policy rule to assert SBOM was included in the built image

### DIFF
--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -39,6 +39,7 @@ import data.lib.refs
 #     - sanity-label-check
 #     - sast-go
 #     - sast-java-sec-check
+#     - sbom-json-check
 #
 deny contains result if {
 	# Find the data in the annotations

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -17,6 +17,7 @@ all_required_task_refs := [
 	"sanity-label-check",
 	"sast-go",
 	"sast-java-sec-check",
+	"sbom-json-check",
 ]
 
 all_bar_two := array.slice(all_required_task_refs, 2, count(all_required_task_refs))

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -21,8 +21,9 @@
 #       - deprecated-image-check
 #       - get-clair-scan
 #       - sanity-inspect-image
-#       - sanity-label-check[POLICY_NAMESPACE=required_checks]
 #       - sanity-label-check[POLICY_NAMESPACE=optional_checks]
+#       - sanity-label-check[POLICY_NAMESPACE=required_checks]
+#       - sbom-json-check
 #
 package policy.release.tasks
 

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -70,6 +70,7 @@ deny contains result if {
 	some att in lib.pipelinerun_attestations
 	_has_tasks(att)
 	missing_tasks := all_required_tasks - _attested_tasks(att)
+	count(missing_tasks) > 0
 	result := lib.result_helper(rego.metadata.chain(), [concat("', '", missing_tasks)])
 }
 

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -3,6 +3,28 @@ package policy.release.tasks
 import data.lib
 import data.lib.bundles
 
+test_all_tasks_present {
+	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as [{"predicate": {
+			"buildType": lib.pipelinerun_att_build_types[0],
+			"buildConfig": {"tasks": [
+				{"ref": {"name": "sanity-inspect-image", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{"ref": {"name": "clamav-scan", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{"ref": {"name": "add-sbom-and-push", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{"ref": {"name": "get-clair-scan", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{"ref": {"name": "deprecated-image-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
+				{
+					"ref": {"name": "sanity-label-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref},
+					"invocation": {"parameters": {"POLICY_NAMESPACE": "required_checks"}},
+				},
+				{
+					"ref": {"name": "sanity-label-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref},
+					"invocation": {"parameters": {"POLICY_NAMESPACE": "optional_checks"}},
+				},
+			]},
+		}}]
+}
+
 test_no_tasks_present {
 	expected := {{
 		"code": "tasks_missing",

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -21,6 +21,7 @@ test_all_tasks_present {
 					"ref": {"name": "sanity-label-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref},
 					"invocation": {"parameters": {"POLICY_NAMESPACE": "optional_checks"}},
 				},
+				{"ref": {"name": "sbom-json-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
 			]},
 		}}]
 }

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -5,25 +5,7 @@ import data.lib.bundles
 
 test_all_tasks_present {
 	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
-		with input.attestations as [{"predicate": {
-			"buildType": lib.pipelinerun_att_build_types[0],
-			"buildConfig": {"tasks": [
-				{"ref": {"name": "sanity-inspect-image", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
-				{"ref": {"name": "clamav-scan", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
-				{"ref": {"name": "add-sbom-and-push", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
-				{"ref": {"name": "get-clair-scan", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
-				{"ref": {"name": "deprecated-image-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
-				{
-					"ref": {"name": "sanity-label-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref},
-					"invocation": {"parameters": {"POLICY_NAMESPACE": "required_checks"}},
-				},
-				{
-					"ref": {"name": "sanity-label-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref},
-					"invocation": {"parameters": {"POLICY_NAMESPACE": "optional_checks"}},
-				},
-				{"ref": {"name": "sbom-json-check", "kind": "Task", "bundle": bundles.acceptable_bundle_ref}},
-			]},
-		}}]
+		with input.attestations as _attestations_with_tasks(all_required_tasks, [])
 }
 
 test_no_tasks_present {


### PR DESCRIPTION
The `sbom-json-checks` task emits the standard `HACBS_TEST_OUTPUT` result. So if the SBOM is either missing or invalid, the result will indicate a failure. This should be covered by the existing policies in the `policy.release.test` package. However, we do want to make sure that this check is always performed. For this reason, the task is added to the list of required tasks.

As part of testing, I noticed that I was hitting the issue described in [HACBS-1366](https://issues.redhat.com/browse/HACBS-1366). I decided to fix that issue as well so I could be re-assured the new policy is working as expected. A unit test was added to ensure the previously breaking scenario is covered.