### PR TITLE
Split data from policy rules

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -1,0 +1,5 @@
+---
+rule_data:
+  allowed_registry_prefixes:
+  - registry.access.redhat.com/
+  - registry.redhat.io/

--- a/policy/release/base_image_registries.rego
+++ b/policy/release/base_image_registries.rego
@@ -24,15 +24,10 @@ import data.lib.bundles
 # custom:
 #   short_name: disallowed_base_image
 #   failure_msg: Base image %q is from a disallowed registry
-#   rule_data:
-#     allowed_registry_prefixes:
-#     - registry.access.redhat.com/
-#     - registry.redhat.io/
 #
 deny contains result if {
-	allowed_registry_prefixes := lib.rule_data(rego.metadata.rule(), "allowed_registry_prefixes")
 	some image_ref in _base_images
-	not _image_ref_permitted(image_ref, allowed_registry_prefixes)
+	not _image_ref_permitted(image_ref, data.rule_data.allowed_registry_prefixes)
 	result := lib.result_helper(rego.metadata.chain(), [image_ref])
 }
 

--- a/policy/release/base_image_registries_test.rego
+++ b/policy/release/base_image_registries_test.rego
@@ -15,6 +15,7 @@ test_acceptable_base_images {
 		bundles.acceptable_bundle_ref,
 	)]
 	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
+		with data.rule_data.allowed_registry_prefixes as ["registry.redhat.io/", "registry.access.redhat.com/"]
 		with input.attestations as attestations
 }
 
@@ -26,6 +27,7 @@ test_empty_base_images {
 		bundles.acceptable_bundle_ref,
 	)]
 	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
+		with data.rule_data.allowed_registry_prefixes as ["registry.redhat.io/", "registry.access.redhat.com/"]
 		with input.attestations as attestations
 }
 
@@ -54,6 +56,7 @@ test_unacceptable_base_images {
 		},
 	}
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with data.rule_data.allowed_registry_prefixes as ["registry.redhat.io/", "registry.access.redhat.com/"]
 		with input.attestations as attestations
 }
 
@@ -70,5 +73,6 @@ test_unacceptable_bundle {
 		"msg": "Base images result is missing",
 	}}
 	lib.assert_equal(deny, expected) with data["task-bundles"] as bundles.bundle_data
+		with data.rule_data.allowed_registry_prefixes as ["registry.redhat.io/", "registry.access.redhat.com/"]
 		with input.attestations as attestations
 }


### PR DESCRIPTION
This allows someone to re-use the policies but provide a different set of data values to be used by the policy rules. For example, it is possible for someone to specify different allowed registries for base images.

At this point, this is meant for illustration purposes for the spike: https://issues.redhat.com/browse/HACBS-1329

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>