### PR TITLE
Add cache-dependency-path for setup-node

### DIFF
--- a/.github/workflows/release-antora-extension.yaml
+++ b/.github/workflows/release-antora-extension.yaml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         cache: 'npm'
+        cache-dependency-path: 'antora/ec-policies-antora-extension/package-lock.json'
         node-version-file: 'antora/ec-policies-antora-extension/package.json'
 
     - name: Publish npm package


### PR DESCRIPTION
Seems that setup-node now looks at the lock file in the workspace root and `cache-dependency-path` needs to be provided for it to find the extension's lock file.