### PR TITLE
Remove suffix `_rules` from policy.configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ clean-data: ## Removes ephemeral files from the `./data` directory
 
 .PHONY: dummy-config
 dummy-config: ## Changes the configuration to mark the `not_useful` check as non-blocking to avoid a "feels like a bad day.." violation
-	@echo '{"config":{"policy":{"non_blocking_checks":["not_useful"]}}}' | jq > $(CONFIG_DATA_FILE)
+	@echo '{"config":{"policy":{"exclude":["not_useful"]}}}' | jq > $(CONFIG_DATA_FILE)
 
 # Set IMAGE as required like this:
 #   make fetch-att IMAGE=<someimage>

--- a/antora/docs/modules/ROOT/templates/policy_configuration.hbs
+++ b/antora/docs/modules/ROOT/templates/policy_configuration.hbs
@@ -27,8 +27,8 @@ Here's an example of how that file might look.
 {
   "config": {
     "policy": {
-      "include_rules": ["*"],
-      "exclude_rules": ["not_useful"],
+      "include": ["*"],
+      "exclude": ["not_useful"],
       "collections": []
     }
   }
@@ -43,8 +43,8 @@ example shows what the defaults are if the configuration is not specified.
 By default, all rules are included, except for the rules in the `not_useful`
 package.
 
-You can modify the defaults by setting `config.policy.include_rules` and
-`config.policy.exclude_rules`. Each of those values should be a list of
+You can modify the defaults by setting `config.policy.include` and
+`config.policy.exclude`. Each of those values should be a list of
 strings.
 
 The strings in the list should be one of the the following:
@@ -83,7 +83,7 @@ xref:release_policy.adoc#test_result_failures["test.test_result_failures" rule]
 only.
 
 The syntax for skipping a particular test is `"test:<testname>"` and it only
-works with the exclude_rules field. You can't use it with the `include_rules`
+works with the exclude field. You can't use it with the `include`
 option.
 
 
@@ -101,7 +101,7 @@ All other rules would be included.
 
 [source,yaml]
 ----
-exclude_rules:
+exclude:
 - attestation_task_bundle
 - not_useful
 ----
@@ -113,7 +113,7 @@ other rules.
 
 [source,yaml]
 ----
-include_rules:
+include:
 - test
 - java
 ----
@@ -126,7 +126,7 @@ the `attestation_task_bundle` package. The other rules in the
 
 [source,yaml]
 ----
-exclude_rules:
+exclude:
 - attestation_task_bundle.unacceptable_task_bundle
 ----
 
@@ -138,7 +138,7 @@ pass even if certain tests failed or didn't complete. Additionally the
 
 [source,yaml]
 ----
-exclude_rules:
+exclude:
 - test:get-clair-scan
 - test:clamav-scan
 - not_useful
@@ -146,7 +146,7 @@ exclude_rules:
 
 === Including only some rules from a package
 
-You can specify both `include_rules` and `exclude_rules` to pick out just the
+You can specify both `include` and `exclude` to pick out just the
 rules you want.
 
 This example specifies that only the `unacceptable_task_bundle` rule from the
@@ -158,16 +158,16 @@ rule in this example.
 
 [source,yaml]
 ----
-include_rules:
+include:
 - "*"
 - attestation_task_bundle.unacceptable_task_bundle
-exclude_rules:
+exclude:
 - attestation_task_bundle.*
 ----
 
 == Specifying a predefined set of rules with `collections`
 
-Rather than specifying the values of `include_rules` and `exclude_rules`
+Rather than specifying the values of `include` and `exclude`
 explicitly, you can also select from a set of predefined configurations by
 setting `"data.config.policy.collections"`. For example, in a `data/config.json`
 file:
@@ -206,9 +206,9 @@ in this git repo.
 == The `non_blocking_checks` field
 
 The `non_blocking_checks` configuration option, previously used to skip rules
-is now deprecated. It's functionality is replaced with the new `exclude_rules`
+is now deprecated. It's functionality is replaced with the new `exclude`
 option as described above. While it's deprecated it can still be used
-interchangeably with the `exclude_rules` field.
+interchangeably with the `exclude` field.
 
 Please make the required tooling changes soon to prevent breakages when the
 `non_blocking_checks` field is removed in the future.

--- a/policy/lib/include_exclude_rules.rego
+++ b/policy/lib/include_exclude_rules.rego
@@ -9,15 +9,15 @@ rule_included(package_name, rule_code) {
 	package_included(package_name)
 
 	# ..and the rule is not explicitly excluded
-	not included_in(full_rule_name, exclude_rules)
+	not included_in(full_rule_name, exclude)
 } else {
 	full_rule_name := package_and_code(package_name, rule_code)
 
 	# The rule is explicitly included, regardless of the package
-	included_in(full_rule_name, include_rules)
+	included_in(full_rule_name, include)
 
 	# ..and not explicitly excluded
-	not included_in(full_rule_name, exclude_rules)
+	not included_in(full_rule_name, exclude)
 }
 
 # At risk of introducing ambiguity by overloading the dot separator,
@@ -35,20 +35,20 @@ package_included(package_name) {
 	package_name_matchers := {package_name, sprintf("%s.*", [package_name]), "*"}
 
 	# Package is in the include list
-	any_included_in(package_name_matchers, include_rules)
+	any_included_in(package_name_matchers, include)
 
 	# ..and not the exclude list
-	none_included_in(package_name_matchers, exclude_rules)
+	none_included_in(package_name_matchers, exclude)
 }
 
-include_rules := to_set(_include_exclude_rules("include", ["*"]))
+include := to_set(_include_exclude("include", ["*"]))
 
-_exclude_rules := to_set(_include_exclude_rules("exclude", []))
+_exclude := to_set(_include_exclude("exclude", []))
 
 # Temporary for backwards compatibility while we deprecate the
 # non_blocking_checks policy configuration
-exclude_rules := r {
-	r := _exclude_rules | to_set(_non_blocking_checks)
+exclude := r {
+	r := _exclude | to_set(_non_blocking_checks)
 }
 
 # Will be removed in future
@@ -59,20 +59,20 @@ _non_blocking_checks := result {
 	result := []
 }
 
-# Look in various places to find the include_rules/exclude_rules lists
-_include_exclude_rules(include_exclude, fallback_default) := result {
+# Look in various places to find the include/exclude lists
+_include_exclude(include_exclude, fallback_default) := result {
 	# A collection was specified in the policy config and we try to to concat the rules from the speicifed
 	# collections with specified include/exclude rules
 	result := array.concat(
 		merge_collection_config(data.config.policy.collections, include_exclude),
-		data.config.policy[sprintf("%s_rules", [include_exclude])],
+		data.config.policy[sprintf("%s", [include_exclude])],
 	)
 } else := result {
 	# No specified include/exclude rules were found, so return include/exclude rules from any specified collections
 	result := merge_collection_config(data.config.policy.collections, include_exclude)
 } else := result {
 	# The list was specified explicitly in the policy config
-	result := data.config.policy[sprintf("%s_rules", [include_exclude])]
+	result := data.config.policy[sprintf("%s", [include_exclude])]
 } else := result {
 	# Use the value from the default collection
 	result := data.rule_collections["default"][include_exclude]

--- a/policy/lib/include_exclude_rules_test.rego
+++ b/policy/lib/include_exclude_rules_test.rego
@@ -3,23 +3,23 @@ package lib
 import data.lib
 
 test_include_defaults {
-	lib.assert_equal(include_rules, {"*"})
-	lib.assert_equal(exclude_rules, set())
+	lib.assert_equal(include, {"*"})
+	lib.assert_equal(exclude, set())
 
-	lib.assert_equal(include_rules, {"zip"}) with data.rule_collections as {"default": {"include": ["zip"]}}
-	lib.assert_equal(exclude_rules, {"zap"}) with data.rule_collections as {"default": {"exclude": ["zap"]}}
+	lib.assert_equal(include, {"zip"}) with data.rule_collections as {"default": {"include": ["zip"]}}
+	lib.assert_equal(exclude, {"zap"}) with data.rule_collections as {"default": {"exclude": ["zap"]}}
 
 	rule_included("foo", "whatever_code")
 }
 
 test_include_config {
 	mock_config := {"policy": {
-		"include_rules": {"foo"},
-		"exclude_rules": {"bar"},
+		"include": {"foo"},
+		"exclude": {"bar"},
 	}}
 
-	lib.assert_equal({"foo"}, include_rules) with data.config as mock_config
-	lib.assert_equal({"bar"}, exclude_rules) with data.config as mock_config
+	lib.assert_equal({"foo"}, include) with data.config as mock_config
+	lib.assert_equal({"bar"}, exclude) with data.config as mock_config
 
 	rule_included("foo", "whatever_code") with data.config as mock_config
 	not rule_included("bar", "whatever_code") with data.config as mock_config
@@ -27,8 +27,8 @@ test_include_config {
 
 test_include_fully_qualified_rules {
 	mock_config_to_include := {"policy": {
-		"exclude_rules": ["*"],
-		"include_rules": ["foo.particular_code"],
+		"exclude": ["*"],
+		"include": ["foo.particular_code"],
 	}}
 
 	rule_included("foo", "particular_code") with data.config as mock_config_to_include
@@ -36,8 +36,8 @@ test_include_fully_qualified_rules {
 	not rule_included("bar", "whatever_code") with data.config as mock_config_to_include
 
 	mock_config_to_exclude := {"policy": {
-		"include_rules": ["*"],
-		"exclude_rules": ["foo.particular_code"],
+		"include": ["*"],
+		"exclude": ["foo.particular_code"],
 	}}
 
 	not rule_included("foo", "particular_code") with data.config as mock_config_to_exclude
@@ -64,16 +64,16 @@ test_merge_collection_config {
 	) with data.config as mock_config_to_include with data.rule_collections as mock_rule_collections
 }
 
-test_include_exclude_rules {
+test_include_exclude {
 	mock_config_with_collections := {"policy": {"collections": ["c1", "c2"]}}
 	mock_config_complete := {"policy": {
 		"collections": ["c1", "c2"],
-		"include_rules": ["eggs", "bacon", "sausage"],
-		"exclude_rules": ["oatmeal", "porridge"],
+		"include": ["eggs", "bacon", "sausage"],
+		"exclude": ["oatmeal", "porridge"],
 	}}
 	mock_config_without_collections := {"policy": {
-		"include_rules": ["eggs", "bacon", "sausage"],
-		"exclude_rules": ["oatmeal", "porridge"],
+		"include": ["eggs", "bacon", "sausage"],
+		"exclude": ["oatmeal", "porridge"],
 	}}
 	mock_config_empty := {"policy": {}}
 
@@ -97,61 +97,61 @@ test_include_exclude_rules {
 	# Test that we get the "include" rules from the collections in the "collections"
 	lib.assert_equal(
 		["toast", "jam", "biscuit", "gravy"],
-		_include_exclude_rules("include", "flugelhorn"),
+		_include_exclude("include", "flugelhorn"),
 	) with data.config as mock_config_with_collections with data.rule_collections as mock_rule_collection
 
-	# Test that we get the "include" rules from the collections in the "collections" key and the rules in "include_rules"
+	# Test that we get the "include" rules from the collections in the "collections" key and the rules in "include"
 	lib.assert_equal(
 		["toast", "jam", "biscuit", "gravy", "eggs", "bacon", "sausage"],
-		_include_exclude_rules("include", "flugelhorn"),
+		_include_exclude("include", "flugelhorn"),
 	) with data.config as mock_config_complete with data.rule_collections as mock_rule_collection
 
-	# Test that we get the "include" rules from the "include_rules" key
+	# Test that we get the "include" rules from the "include" key
 	lib.assert_equal(
 		["eggs", "bacon", "sausage"],
-		_include_exclude_rules("include", "flugelhorn"),
+		_include_exclude("include", "flugelhorn"),
 	) with data.config as mock_config_without_collections with data.rule_collections as mock_rule_collection
 
 	# Test that we get the default "include" rule when we have an empty policy
 	lib.assert_equal(
 		["*"],
-		_include_exclude_rules("include", "flugelhorn"),
+		_include_exclude("include", "flugelhorn"),
 	) with data.config as mock_config_empty with data.rule_collections as mock_rule_collection
 
 	# Test that we get the fallback_rule when we have an empty config and an empty ruleset
 	lib.assert_equal(
 		["flugelhorn"],
-		_include_exclude_rules("include", ["flugelhorn"]),
+		_include_exclude("include", ["flugelhorn"]),
 	) with data.config as mock_config_empty with data.rule_collections as mock_rule_collection_empty
 
 	## Exclude Tests
 	# Test that we get the "exclude" rules from the collections in the "collections"
 	lib.assert_equal(
 		["scone", "muffin"],
-		_include_exclude_rules("exclude", "flugelhorn"),
+		_include_exclude("exclude", "flugelhorn"),
 	) with data.config as mock_config_with_collections with data.rule_collections as mock_rule_collection
 
-	# Test that we get the "exclude" rules from the collections in the "collections" key and the rules in "exclude_rules"
+	# Test that we get the "exclude" rules from the collections in the "collections" key and the rules in "exclude"
 	lib.assert_equal(
 		["scone", "muffin", "oatmeal", "porridge"],
-		_include_exclude_rules("exclude", "flugelhorn"),
+		_include_exclude("exclude", "flugelhorn"),
 	) with data.config as mock_config_complete with data.rule_collections as mock_rule_collection
 
-	# Test that we get the "exclude" rules from the "exclude_rules" key
+	# Test that we get the "exclude" rules from the "exclude" key
 	lib.assert_equal(
 		["oatmeal", "porridge"],
-		_include_exclude_rules("exclude", "flugelhorn"),
+		_include_exclude("exclude", "flugelhorn"),
 	) with data.config as mock_config_without_collections with data.rule_collections as mock_rule_collection
 
 	# Test that we get the default "include" rule when we have an empty policy
 	lib.assert_equal(
 		["not_useful"],
-		_include_exclude_rules("exclude", "flugelhorn"),
+		_include_exclude("exclude", "flugelhorn"),
 	) with data.config as mock_config_empty with data.rule_collections as mock_rule_collection
 
 	# Test that we get the fallback_rule when we have an empty config and an empty ruleset
 	lib.assert_equal(
 		["flugelhorn"],
-		_include_exclude_rules("exclude", ["flugelhorn"]),
+		_include_exclude("exclude", ["flugelhorn"]),
 	) with data.config as mock_config_empty with data.rule_collections as mock_rule_collection_empty
 }

--- a/policy/lib/main_denies_test.rego
+++ b/policy/lib/main_denies_test.rego
@@ -24,13 +24,13 @@ test_future_handling {
 	lib.assert_equal({future_denial}, lib.future_rules({future_denial, current_denial}))
 }
 
-test_include_exclude_rules {
+test_include_exclude {
 	# Rules excluded by wildcard
-	lib.assert_empty(current_and_future_denies("release")) with data.config.policy.exclude_rules as ["*"]
+	lib.assert_empty(current_and_future_denies("release")) with data.config.policy.exclude as ["*"]
 
 	# Rules excluded by name
-	lib.assert_empty(current_and_future_denies("pipeline")) with data.config.policy.exclude_rules as ["required_tasks"]
+	lib.assert_empty(current_and_future_denies("pipeline")) with data.config.policy.exclude as ["required_tasks"]
 
 	# Rules included by name
-	lib.assert_equal(1, count(current_and_future_denies("pipeline"))) with data.config.policy.include_rules as ["required_tasks"]
+	lib.assert_equal(1, count(current_and_future_denies("pipeline"))) with data.config.policy.include as ["required_tasks"]
 }

--- a/policy/pipeline/main_test.rego
+++ b/policy/pipeline/main_test.rego
@@ -4,7 +4,7 @@ import data.lib
 
 test_passing {
 	lib.assert_empty(deny) with input.kind as "Pipeline"
-		with data.config.policy.non_blocking_checks as ["required_tasks"]
+		with data.config.policy.exclude as ["required_tasks"]
 }
 
 test_failing {
@@ -13,7 +13,7 @@ test_failing {
 		"msg": "Unexpected kind 'Zipline'",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.kind as "Zipline"
-		with data.config.policy.non_blocking_checks as ["required_tasks"]
+		with data.config.policy.exclude as ["required_tasks"]
 }
 
 test_in_future {

--- a/policy/release/examples/time_based_test.rego
+++ b/policy/release/examples/time_based_test.rego
@@ -19,12 +19,12 @@ test_not_effective_by_default {
 	# time_based policy has effective_on far into the future, if you're reading
 	# this then bump it for another 100 years
 	lib.assert_equal({no_effective_date, in_the_past, y2k}, data.release.main.deny) with data.policy.release as {data.examples.release.time_based}
-		with data.config.policy.non_blocking_checks as []
+		with data.config.policy.exclude as []
 }
 
 test_effective_with_time_travel {
 	# Set the date/time to the future where the example policy becomes effective.
-	policy_config := {"non_blocking_checks": [], "when_ns": time.parse_rfc3339_ns("2099-05-02T00:00:00Z")}
+	policy_config := {"exclude": [], "when_ns": time.parse_rfc3339_ns("2099-05-02T00:00:00Z")}
 
 	# The time based filtering happens automatically on the real polices. Replace
 	# those with our example policy.
@@ -34,7 +34,7 @@ test_effective_with_time_travel {
 
 test_y2k_not_failing_before_2000 {
 	# Set the date/time to the future where the example policy becomes effective.
-	policy_config := {"non_blocking_checks": [], "when_ns": time.parse_rfc3339_ns("1999-01-01T00:00:00Z")}
+	policy_config := {"exclude": [], "when_ns": time.parse_rfc3339_ns("1999-01-01T00:00:00Z")}
 
 	# The time based filtering happens automatically on the real polices. Replace
 	# those with our example policy.

--- a/policy/release/main_test.rego
+++ b/policy/release/main_test.rego
@@ -8,11 +8,11 @@ import data.lib.bundles
 all_tests := {p | data.policy.release[policy]; p := policy}
 
 nonblocking_except(except_tests) = d {
-	d := {"non_blocking_checks": all_tests - except_tests}
+	d := {"exclude": all_tests - except_tests}
 }
 
 nonblocking_only(only_tests) = d {
-	d := {"non_blocking_checks": only_tests}
+	d := {"exclude": only_tests}
 }
 
 test_main {
@@ -44,15 +44,15 @@ test_skipping_individual_rules {
 		"code": "test_data_missing",
 		"msg": "No test data found",
 		"effective_on": "2022-01-01T00:00:00Z",
-	}}) with data.config.policy.exclude_rules as ["not_useful.bad_day"]
+	}}) with data.config.policy.exclude as ["not_useful.bad_day"]
 
 	lib.assert_equal(deny, {{
 		"code": "bad_day",
 		"msg": "It just feels like a bad day to do a release",
 		"effective_on": "2022-01-01T00:00:00Z",
-	}}) with data.config.policy.exclude_rules as ["test.test_data_missing"]
+	}}) with data.config.policy.exclude as ["test.test_data_missing"]
 
-	lib.assert_empty(deny) with data.config.policy.exclude_rules as ["test.test_data_missing", "not_useful.bad_day"]
+	lib.assert_empty(deny) with data.config.policy.exclude as ["test.test_data_missing", "not_useful.bad_day"]
 }
 
 test_succeeding_when_skipping_all {

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -92,8 +92,8 @@ deny[result] {
 	all_failed = resulted_in({"FAILURE", "ERROR"})
 
 	# Failed tests are those contained within all_failed that are not
-	# listed in the exclude_rules list
-	failed_blocking := all_failed - lib.exclude_rules
+	# listed in the exclude list
+	failed_blocking := all_failed - lib.exclude
 
 	# Fail if there are any
 	count(failed_blocking) > 0

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -45,7 +45,7 @@ mock_a_passing_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name,
 test_success_data {
 	lib.assert_empty(deny) with input.attestations as mock_a_passing_test
 		with data["task-bundles"] as bundles.bundle_data
-		with data.config.policy as {"non_blocking_checks": []}
+		with data.config.policy as {"exclude": []}
 }
 
 mock_a_failing_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "failed_1", bundles.acceptable_bundle_ref)]
@@ -57,7 +57,7 @@ test_failure_data {
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as mock_a_failing_test
-		with data.config.policy as {"non_blocking_checks": []}
+		with data.config.policy as {"exclude": []}
 }
 
 mock_an_errored_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "errored_1", bundles.acceptable_bundle_ref)]
@@ -69,7 +69,7 @@ test_error_data {
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as mock_an_errored_test
-		with data.config.policy as {"non_blocking_checks": []}
+		with data.config.policy as {"exclude": []}
 }
 
 mock_mixed_data := array.concat(mock_a_failing_test, mock_an_errored_test)
@@ -81,7 +81,7 @@ test_mix_data {
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as mock_mixed_data
-		with data.config.policy as {"non_blocking_checks": []}
+		with data.config.policy as {"exclude": []}
 }
 
 test_can_skip_by_name {
@@ -89,15 +89,15 @@ test_can_skip_by_name {
 		with input.attestations as mock_mixed_data
 		with data.config.policy as {"non_blocking_checks": ["test:errored_1", "test:failed_1"]}
 
-	# Exclude_rules works the same as non_blocking_checks
+	# exclude works the same as non_blocking_checks
 	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as mock_mixed_data
-		with data.config.policy as {"exclude_rules": ["test:errored_1", "test:failed_1"]}
+		with data.config.policy as {"exclude": ["test:errored_1", "test:failed_1"]}
 
 	# It's an unlikely edge case, but you can use them both if you want
 	lib.assert_empty(deny) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as mock_mixed_data
-		with data.config.policy as {"exclude_rules": ["test:errored_1"], "non_blocking_checks": ["test:failed_1"]}
+		with data.config.policy as {"exclude": ["test:errored_1"], "non_blocking_checks": ["test:failed_1"]}
 
 	lib.assert_equal(deny, {{
 		"code": "test_result_failures",
@@ -107,14 +107,14 @@ test_can_skip_by_name {
 		with input.attestations as mock_mixed_data
 		with data.config.policy as {"non_blocking_checks": ["test:failed_1"]}
 
-	# Exclude_rules works the same as non_blocking_checks
+	# exclude works the same as non_blocking_checks
 	lib.assert_equal(deny, {{
 		"code": "test_result_failures",
 		"msg": "The following tests did not complete successfully: errored_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as mock_mixed_data
-		with data.config.policy as {"exclude_rules": ["test:failed_1"]}
+		with data.config.policy as {"exclude": ["test:failed_1"]}
 }
 
 test_skipped_is_not_deny {
@@ -183,5 +183,5 @@ test_unacceptable_bundle_results {
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "task1", "registry.img/unacceptable@sha256:digest")]
 		with data["task-bundles"] as bundles.bundle_data
-		with data.config.policy as {"non_blocking_checks": []}
+		with data.config.policy as {"exclude": []}
 }


### PR DESCRIPTION
Renames `include_rules` to `include` and `exclude_rules` to `exclude`.

Also makes use of `exclude` instead of the deprecated `non_blocking_checks` in the tests.