### PR TITLE
Validate collection consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ opa-check: ## Check Rego files with strict mode (https://www.openpolicyagent.org
 
 .PHONY: conventions-check
 conventions-check: ## Check Rego policy files for convention violations
-	@OUT=$$(opa eval --data checks --data $(POLICY_DIR)/lib --input <(opa inspect . -a -f json) 'data.checks.violation[_]' --format raw); \
+	@OUT=$$(opa eval --data checks --data $(POLICY_DIR)/lib --data data --input <(opa inspect . -a -f json) 'data.checks.violation[_]' --format raw); \
 	if [[ -n "$${OUT}" ]]; then echo "$${OUT}"; exit 1; fi
 
 .PHONY: ready

--- a/checks/collections.rego
+++ b/checks/collections.rego
@@ -1,0 +1,16 @@
+package checks
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+violation contains msg if {
+	some collection, def in data.rule_collections
+	missing := [r |
+		some r in array.concat(def.include, def.exclude)
+		r != "*"
+		not input.namespaces[sprintf("data.policy.release.%s", [r])]
+	]
+	count(missing) > 0
+	msg := sprintf("ERROR: The collection `%s` references non-existant package(s): %s", [collection, concat(", ", missing)])
+}

--- a/checks/collections_test.rego
+++ b/checks/collections_test.rego
@@ -1,0 +1,26 @@
+package checks
+
+import data.lib
+
+test_valid_collection {
+	lib.assert_empty(violation) with input as {"namespaces": {
+		"data.policy.release.rule1": [],
+		"data.policy.release.rule2": [],
+		"data.policy.release.rule3": [],
+	}}
+		with data.rule_collections as {"collection": {
+			"include": ["rule1", "rule3"],
+			"exclude": ["rule2"],
+		}}
+}
+
+test_invalid_collection {
+	lib.assert_equal({"ERROR: The collection `collection` references non-existant package(s): rule1, rule2"}, violation) with input as {"namespaces": {
+		"data.policy.release.rule3": [],
+		"data.policy.release.rule4": [],
+	}}
+		with data.rule_collections as {"collection": {
+			"include": ["rule1"],
+			"exclude": ["rule2"],
+		}}
+}


### PR DESCRIPTION
This adds a convention check to make sure that the defined collections are consistent, i.e. they do not reference non-existent rules.

Ref. https://issues.redhat.com/browse/HACBS-1422