### PR TITLE
Consider missing test results only in PipelineRuns

### DIFF
--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -28,6 +28,7 @@ import future.keywords.in
 #   failure_msg: No test data found
 #
 deny[result] {
+	count(lib.pipelinerun_attestations) > 0 # make sure we're looking at a PipelineRun attestation
 	results := lib.results_from_tests
 	count(results) == 0 # there are none at all
 

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -185,3 +185,19 @@ test_unacceptable_bundle_results {
 		with data["task-bundles"] as bundles.bundle_data
 		with data.config.policy as {"exclude": []}
 }
+
+test_missing_wrong_attestation_type {
+	pr := lib.att_mock_helper_ref("some-result", {"result": "value"}, "task1", bundles.acceptable_bundle_ref)
+	tr := object.union(pr, {"predicate": {"buildType": lib.taskrun_att_build_types[0]}})
+	lib.assert_empty(deny) with input.attestations as [tr]
+		with data["task-bundles"] as bundles.bundle_data
+		with data.config.policy as {"exclude": []}
+}
+
+test_wrong_attestation_type {
+	pr := lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "errored_1", bundles.acceptable_bundle_ref)
+	tr := object.union(pr, {"predicate": {"buildType": lib.taskrun_att_build_types[0]}})
+	lib.assert_empty(deny) with input.attestations as [tr]
+		with data["task-bundles"] as bundles.bundle_data
+		with data.config.policy as {"exclude": []}
+}


### PR DESCRIPTION
Given that the ec cli now passes through both TaskRun and PipelineRun attestation input it considers test results missing when examining the TaskRun attestation input, resulting in the `test_data_missing` error being reported.
This makes sure that `test_data_missing` error is reported only if the examined input is a PipelineRun attestation.