### PR TITLE
Remove support for multi-stream bundle repos

### DIFF
--- a/policy/lib/bundles_test.rego
+++ b/policy/lib/bundles_test.rego
@@ -36,11 +36,11 @@ test_unpinned_task_bundle {
 	tasks := [
 		{
 			"name": "my-task-1",
-			"taskRef": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2"},
+			"taskRef": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5"},
 		},
 		{
 			"name": "my-task-2",
-			"ref": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2"},
+			"ref": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5"},
 		},
 	]
 
@@ -62,26 +62,6 @@ test_acceptable_bundle {
 	lib.assert_empty(unacceptable_task_bundle(tasks)) with data["task-bundles"] as task_bundles
 }
 
-# All good when the most recent bundle is used when streams are used.
-test_acceptable_bundle_up_to_date_with_streams {
-	tasks := [
-		{
-			"name": "my-task-1",
-			"taskRef": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2@sha256:abc"},
-		},
-		{
-			"name": "my-task-2",
-			"ref": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-2@sha256:abc"},
-		},
-	]
-
-	lib.assert_empty(disallowed_task_reference(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(empty_task_bundle_reference(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(unpinned_task_bundle(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(out_of_date_task_bundle(tasks)) with data["task-bundles"] as task_bundles
-	lib.assert_empty(unacceptable_task_bundle(tasks)) with data["task-bundles"] as task_bundles
-}
-
 test_out_of_date_task_bundle {
 	tasks := [
 		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:bcd"}},
@@ -94,51 +74,10 @@ test_out_of_date_task_bundle {
 	lib.assert_equal(out_of_date_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
 }
 
-test_out_of_date_task_bundle_with_streams {
-	# Verify streams are honored
-	tasks := [
-		{
-			"name": "my-task-1",
-			"taskRef": {"bundle": "reg.com/repo:b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2@sha256:bcd"},
-		},
-		{
-			"name": "my-task-2",
-			"taskRef": {"bundle": "reg.com/repo:120dda49a6cc3b89516b491e19fe1f3a07f1427f-2@sha256:cde"},
-		},
-		{
-			"name": "my-task-3",
-			"taskRef": {"bundle": "reg.com/repo:b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2@sha256:bcd"},
-		},
-		{
-			"name": "my-task-4",
-			"taskRef": {"bundle": "reg.com/repo:120dda49a6cc3b89516b491e19fe1f3a07f1427f-2@sha256:cde"},
-		},
-	]
-
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(out_of_date_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
-}
-
 test_unacceptable_task_bundles {
 	tasks := [
 		{"name": "my-task-1", "taskRef": {"bundle": "reg.com/repo@sha256:def"}},
 		{"name": "my-task-2", "ref": {"bundle": "reg.com/repo@sha256:def"}},
-	]
-
-	expected := {task | task := tasks[_]}
-	lib.assert_equal(unacceptable_task_bundle(tasks), expected) with data["task-bundles"] as task_bundles
-}
-
-test_unacceptable_task_bundles_with_streams {
-	tasks := [
-		{
-			"name": "my-task-1",
-			"taskRef": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-1@sha256:def"},
-		},
-		{
-			"name": "my-task-2",
-			"ref": {"bundle": "reg.com/repo:903d49a833d22f359bce3d67b15b006e1197bae5-1@sha256:def"},
-		},
 	]
 
 	expected := {task | task := tasks[_]}
@@ -167,82 +106,25 @@ test_is_equal {
 	lib.assert_equal(is_equal(record, {"digest": "", "tag": "not-spam"}), false)
 }
 
-test_stream {
-	lib.assert_equal(_stream(""), "default")
-	lib.assert_equal(_stream("spam"), "default")
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5"), "default")
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-9-9"), "default")
-	lib.assert_equal(_stream("spam-903d49a833d22f359bce3d67b15b006e1197bae5-2"), "default")
-
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-2"), "2")
-	lib.assert_equal(_stream("903d49a833d22f359bce3d67b15b006e1197bae5-999"), "999")
-}
-
-test_tag_by_digest {
-	refs := [
-		{
-			"digest": "sha256:abc",
-			"tag": "ignore-me",
-		},
-		{
-			"digest": "sha256:bcd",
-			"tag": "the-tag",
-		},
-		{
-			"digest": "sha256:bcd",
-			"tag": "repeat-digest",
-		},
-	]
-
-	# The first match is found
-	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:bcd", "tag": ""}), "the-tag")
-
-	# Skip search if tag is already provided
-	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:bcd", "tag": "tag-known"}), "tag-known")
-
-	# No match found
-	lib.assert_equal(_tag_by_digest(refs, {"digest": "sha256:cde", "tag": ""}), "")
-}
-
 task_bundles = {"reg.com/repo": [
 	{
-		"digest": "sha256:012", # Ignore
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-1",
-		"effective_on": "2262-04-11T00:00:00Z",
-	},
-	{
 		"digest": "sha256:abc", # Allow
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-2",
+		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5",
 		"effective_on": "2262-04-11T00:00:00Z",
-	},
-	{
-		"digest": "sha256:123", # Ignore
-		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-1",
-		"effective_on": "2262-03-11T00:00:00Z",
 	},
 	{
 		"digest": "sha256:bcd", # Warn
-		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af-2",
+		"tag": "b7d8f6ae908641f5f2309ee6a9d6b2b83a56e1af",
 		"effective_on": "2262-03-11T00:00:00Z",
 	},
 	{
-		"digest": "sha256:234", # Ignore
-		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f-1",
-		"effective_on": "2022-02-01T00:00:00Z",
-	},
-	{
 		"digest": "sha256:cde", # Warn
-		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f-2",
+		"tag": "120dda49a6cc3b89516b491e19fe1f3a07f1427f",
 		"effective_on": "2022-02-01T00:00:00Z",
-	},
-	{
-		"digest": "sha256:345", # Ignore
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-1",
-		"effective_on": "2021-01-01T00:00:00Z",
 	},
 	{
 		"digest": "sha256:def", # Warn
-		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5-2",
+		"tag": "903d49a833d22f359bce3d67b15b006e1197bae5",
 		"effective_on": "2021-01-01T00:00:00Z",
 	},
 ]}


### PR DESCRIPTION
The task Tekton bundles produced by the
redhat-appstudio/build-definitions repository used to have a very unique structure. All the task definitions were split into chunks of 10, a bundle would then created for each chunk, finally all bundles would be pushed to the *same* OCI repository. To differentiate between the different chunks, a digit suffix was added to the tag of each bundle. So for the commit "abc", three Tekton bundles would be pushed to the same repo, "abc-1", "abc-2", and "abc-3".

In order to properly determine if an acceptable bundle was being used, the policies had to understand this structure. This was done by dynamically splitting the list of bundles by the tag pattern, so "abc-1" and "bcd-1" were on the same sub-list, but "abc-2" and "bcd-2" were on a separate sub-list. Each sub-list was dubbed a "stream". This approach was good enough in most cases. Its main drawback was the fact that it was very specific to the build-definitions repository and unlikely to ever be adopted by any other repository.

The build-definitions repository has moved away from this structure (great!). Now each bundle contains a single task, and, more importantly, each bundle is pushed to its own repository.

Since this logic is now irrelevant, it is with great pleasure removed from the code based due to its complexity. (Even explaining the feature itself is difficult!)

https://issues.redhat.com/browse/HACBS-1364

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>