### PR TITLE
Ignore buildah policy for non pipeline run att

### DIFF
--- a/policy/release/buildah_build_task.rego
+++ b/policy/release/buildah_build_task.rego
@@ -20,6 +20,8 @@ import data.lib
 #   short_name: dockerfile_param_not_included
 #   failure_msg: DOCKERFILE param is not included in the task
 deny contains result if {
+	# Skip this rule if the buildah task is not present
+	buildah_task
 	not dockerfile_param
 	result := lib.result_helper(rego.metadata.chain(), [])
 }

--- a/policy/release/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task_test.rego
@@ -7,7 +7,9 @@ import future.keywords.in
 import data.lib
 
 test_good_dockerfile_param if {
-	lib.assert_equal(set(), deny) with input.attestations as [_attestation("buildah", {"parameters": {"DOCKERFILE": "./Dockerfile"}})] with data["task-bundles"] as lib.bundles.bundle_data
+	attestation := _attestation("buildah", {"parameters": {"DOCKERFILE": "./Dockerfile"}})
+	lib.assert_equal(set(), deny) with input.attestations as [attestation]
+		with data["task-bundles"] as lib.bundles.bundle_data
 }
 
 test_dockerfile_param_https_source if {
@@ -16,7 +18,9 @@ test_dockerfile_param_https_source if {
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param value (https://Dockerfile) is an external source",
 	}}
-	lib.assert_equal(expected, deny) with input.attestations as [_attestation("buildah", {"parameters": {"DOCKERFILE": "https://Dockerfile"}})] with data["task-bundles"] as lib.bundles.bundle_data
+	attestation := _attestation("buildah", {"parameters": {"DOCKERFILE": "https://Dockerfile"}})
+	lib.assert_equal(expected, deny) with input.attestations as [attestation]
+		with data["task-bundles"] as lib.bundles.bundle_data
 }
 
 test_dockerfile_param_http_source if {
@@ -25,7 +29,9 @@ test_dockerfile_param_http_source if {
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param value (http://Dockerfile) is an external source",
 	}}
-	lib.assert_equal(expected, deny) with input.attestations as [_attestation("buildah", {"parameters": {"DOCKERFILE": "http://Dockerfile"}})] with data["task-bundles"] as lib.bundles.bundle_data
+	attestation := _attestation("buildah", {"parameters": {"DOCKERFILE": "http://Dockerfile"}})
+	lib.assert_equal(expected, deny) with input.attestations as [attestation]
+		with data["task-bundles"] as lib.bundles.bundle_data
 }
 
 test_dockerfile_param_not_included if {

--- a/policy/release/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task_test.rego
@@ -35,15 +35,17 @@ test_dockerfile_param_not_included if {
 		"msg": "DOCKERFILE param is not included in the task",
 	}}
 	lib.assert_equal(expected, deny) with input.attestations as [_attestation("buildah", {})]
+		with data["task-bundles"] as lib.bundles.bundle_data
 }
 
 test_task_not_named_buildah if {
-	expected := {{
-		"code": "dockerfile_param_not_included",
-		"effective_on": "2022-01-01T00:00:00Z",
-		"msg": "DOCKERFILE param is not included in the task",
-	}}
-	lib.assert_equal(expected, deny) with input.attestations as [_attestation("java", {})]
+	lib.assert_empty(deny) with input.attestations as [_attestation("java", {})]
+		with data["task-bundles"] as lib.bundles.bundle_data
+}
+
+test_missing_pipeline_run_attestations if {
+	attestation := {"predicate": {"buildType": "something/else"}}
+	lib.assert_empty(deny) with input.attestations as [attestation]
 }
 
 _attestation(task_name, params) = attestation if {


### PR DESCRIPTION
The policy rule dockerfile_param_not_included is only meant to be executed when there's a pipeline run attestation.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>