### PR TITLE
Display package name in violation code

### DIFF
--- a/policy/lib/result_helper.rego
+++ b/policy/lib/result_helper.rego
@@ -8,8 +8,13 @@ result_helper(chain, failure_sprintf_params) := result {
 	# Thus, result_helper assumes every rule defines annotations.
 	rule_annotations := chain[0].annotations
 	result := {
-		"code": rule_annotations.custom.short_name,
+		"code": concat(".", [_pkg_name(chain), rule_annotations.custom.short_name]),
 		"msg": sprintf(rule_annotations.custom.failure_msg, failure_sprintf_params),
 		"effective_on": time_lib.when(chain),
 	}
+}
+
+_pkg_name(chain) := name {
+	path := chain[count(chain) - 1].path
+	name := path[count(path) - 1]
 }

--- a/policy/lib/result_helper_test.rego
+++ b/policy/lib/result_helper_test.rego
@@ -7,8 +7,13 @@ mock_annotations := {"custom": {
 	"failure_msg": "Bad thing %s",
 }}
 
-expected_result := {"code": "Hey", "effective_on": "2022-01-01T00:00:00Z", "msg": "Bad thing foo"}
+expected_result := {"code": "oh.Hey", "effective_on": "2022-01-01T00:00:00Z", "msg": "Bad thing foo"}
 
 test_result_helper {
-	lib.assert_equal(expected_result, result_helper([{"annotations": mock_annotations}], ["foo"]))
+	chain := [
+		{"annotations": mock_annotations, "path": []},
+		{"annotations": {}, "path": ["ignored", "oh"]},
+	]
+
+	lib.assert_equal(expected_result, result_helper(chain, ["foo"]))
 }

--- a/policy/pipeline/basic_test.rego
+++ b/policy/pipeline/basic_test.rego
@@ -4,7 +4,7 @@ import data.lib
 
 test_unexpected_kind {
 	lib.assert_equal(deny, {{
-		"code": "unexpected_kind",
+		"code": "basic.unexpected_kind",
 		"msg": "Unexpected kind 'Foo'",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.kind as "Foo"

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -83,7 +83,7 @@ test_current_equal_latest_also if {
 
 test_no_tasks_present if {
 	expected := {{
-		"code": "tasks_missing",
+		"code": "required_tasks.tasks_missing",
 		"msg": "No tasks found in Pipeline definition",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}
@@ -174,7 +174,7 @@ _missing_tasks_violation(tasks) = errors if {
 	errors := {error |
 		some task in tasks
 		error := {
-			"code": "missing_required_task",
+			"code": "required_tasks.missing_required_task",
 			"msg": sprintf("Required task %q is missing", [task]),
 			"effective_on": "2022-01-01T00:00:00Z",
 		}
@@ -185,7 +185,7 @@ _missing_tasks_warning(tasks) = warnings if {
 	warnings := {warning |
 		some task in tasks
 		warning := {
-			"code": "missing_future_required_task",
+			"code": "required_tasks.missing_future_required_task",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": sprintf("Task %q is missing and will be required in the future", [task]),
 		}

--- a/policy/pipeline/task_bundle_test.rego
+++ b/policy/pipeline/task_bundle_test.rego
@@ -7,7 +7,7 @@ test_bundle_not_exists {
 
 	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
 	lib.assert_equal(deny, {{
-		"code": "disallowed_task_reference",
+		"code": "task_bundle.disallowed_task_reference",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.spec.tasks as tasks
@@ -20,7 +20,7 @@ test_bundle_not_exists_empty_string {
 
 	expected_msg := "Pipeline task 'my-task' uses an empty bundle image reference"
 	lib.assert_equal(deny, {{
-		"code": "empty_task_bundle_reference",
+		"code": "task_bundle.empty_task_bundle_reference",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.spec.tasks as tasks
@@ -36,7 +36,7 @@ test_bundle_unpinned {
 
 	lib.assert_empty(deny) with input.spec.tasks as tasks
 	lib.assert_equal(warn, {{
-		"code": "unpinned_task_bundle",
+		"code": "task_bundle.unpinned_task_bundle",
 		"msg": "Pipeline task 'my-task' uses an unpinned task bundle reference 'reg.com/repo:latest'",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.spec.tasks as tasks
@@ -72,12 +72,12 @@ test_acceptable_bundle_out_of_date_past {
 
 	lib.assert_equal(warn, {
 		{
-			"code": "out_of_date_task_bundle",
+			"code": "task_bundle.out_of_date_task_bundle",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Pipeline task 'my-task-1' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
 		},
 		{
-			"code": "out_of_date_task_bundle",
+			"code": "task_bundle.out_of_date_task_bundle",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Pipeline task 'my-task-2' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
 		},
@@ -96,7 +96,7 @@ test_acceptable_bundle_expired {
 		with data["task-bundles"] as task_bundles
 
 	lib.assert_equal(deny, {{
-		"code": "unacceptable_task_bundle",
+		"code": "task_bundle.unacceptable_task_bundle",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Pipeline task 'my-task' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.spec.tasks as tasks

--- a/policy/release/attestation_task_bundle_test.rego
+++ b/policy/release/attestation_task_bundle_test.rego
@@ -18,7 +18,7 @@ test_bundle_not_exists {
 
 	expected_msg := "Pipeline task 'my-task' does not contain a bundle reference"
 	lib.assert_equal(deny, {{
-		"code": "disallowed_task_reference",
+		"code": "attestation_task_bundle.disallowed_task_reference",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as d
@@ -36,7 +36,7 @@ test_bundle_not_exists_empty_string {
 
 	expected_msg := sprintf("Pipeline task '%s' uses an empty bundle image reference", [name])
 	lib.assert_equal(deny, {{
-		"code": "empty_task_bundle_reference",
+		"code": "attestation_task_bundle.empty_task_bundle_reference",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as d
@@ -58,7 +58,7 @@ test_bundle_unpinned {
 	lib.assert_empty(deny) with input.attestations as d
 	expected_msg := sprintf("Pipeline task '%s' uses an unpinned task bundle reference '%s'", [name, image])
 	lib.assert_equal(warn, {{
-		"code": "unpinned_task_bundle",
+		"code": "attestation_task_bundle.unpinned_task_bundle",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as d
@@ -96,12 +96,12 @@ test_acceptable_bundle_out_of_date_past {
 
 	lib.assert_equal(warn, {
 		{
-			"code": "out_of_date_task_bundle",
+			"code": "attestation_task_bundle.out_of_date_task_bundle",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Pipeline task 'task-run-0' uses an out of date task bundle 'reg.com/repo@sha256:bcd'",
 		},
 		{
-			"code": "out_of_date_task_bundle",
+			"code": "attestation_task_bundle.out_of_date_task_bundle",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Pipeline task 'task-run-1' uses an out of date task bundle 'reg.com/repo@sha256:cde'",
 		},
@@ -119,7 +119,7 @@ test_acceptable_bundle_expired {
 		with data["task-bundles"] as task_bundles
 
 	lib.assert_equal(deny, {{
-		"code": "unacceptable_task_bundle",
+		"code": "attestation_task_bundle.unacceptable_task_bundle",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Pipeline task 'task-run-0' uses an unacceptable task bundle 'reg.com/repo@sha256:def'",
 	}}) with input.attestations as attestations

--- a/policy/release/attestation_type_test.rego
+++ b/policy/release/attestation_type_test.rego
@@ -17,7 +17,7 @@ test_allow_when_permitted {
 test_deny_when_not_permitted {
 	expected_msg := sprintf("Unknown attestation type '%s'", [bad_type])
 	lib.assert_equal(deny, {{
-		"code": "unknown_att_type",
+		"code": "attestation_type.unknown_att_type",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_data(bad_type)

--- a/policy/release/authorization_test.rego
+++ b/policy/release/authorization_test.rego
@@ -17,7 +17,7 @@ commit_sha := "1234"
 test_no_authorization {
 	expected_msg := "No authorization data found"
 	lib.assert_equal(deny, {{
-		"code": "disallowed_no_authorization",
+		"code": "authorization.disallowed_no_authorization",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as lib.att_mock_materials(git_repo, commit_sha) with data.authorization as mock_empty_data
@@ -26,7 +26,7 @@ test_no_authorization {
 test_commit_does_not_match {
 	expected_msg := sprintf("Commit %s does not match authorized commit %s", [commit_sha, "2468"])
 	lib.assert_equal(deny, {{
-		"code": "disallowed_commit_does_not_match",
+		"code": "authorization.disallowed_commit_does_not_match",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as lib.att_mock_materials(git_repo, commit_sha) with data.authorization as mock_data("2468", git_repo, "ec@redhat.com")
@@ -35,7 +35,7 @@ test_commit_does_not_match {
 test_repo_does_not_match {
 	expected_msg := sprintf("Repo url %s does not match authorized repo url %s", [git_repo, "https://github.com/hacbs-contract/authorized.git"])
 	lib.assert_equal(deny, {{
-		"code": "disallowed_repo_url_does_not_match",
+		"code": "authorization.disallowed_repo_url_does_not_match",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as lib.att_mock_materials(git_repo, commit_sha) with data.authorization as mock_data(commit_sha, "https://github.com/hacbs-contract/authorized.git", "ec@redhat.com")

--- a/policy/release/base_image_registries_test.rego
+++ b/policy/release/base_image_registries_test.rego
@@ -43,12 +43,12 @@ test_unacceptable_base_images {
 	)]
 	expected := {
 		{
-			"code": "disallowed_base_image",
+			"code": "base_image_registries.disallowed_base_image",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Base image \"docker.io/busybox:latest@sha256:bcd\" is from a disallowed registry",
 		},
 		{
-			"code": "disallowed_base_image",
+			"code": "base_image_registries.disallowed_base_image",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Base image \"registry.redhat.ioo/spam:latest@sha256:def\" is from a disallowed registry",
 		},
@@ -65,7 +65,7 @@ test_unacceptable_bundle {
 		"registry.img/unacceptable@sha256:012",
 	)]
 	expected := {{
-		"code": "base_images_missing",
+		"code": "base_image_registries.base_images_missing",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Base images result is missing",
 	}}

--- a/policy/release/buildah_build_task_test.rego
+++ b/policy/release/buildah_build_task_test.rego
@@ -14,7 +14,7 @@ test_good_dockerfile_param if {
 
 test_dockerfile_param_https_source if {
 	expected := {{
-		"code": "dockerfile_param_external_source",
+		"code": "buildah_build_task.dockerfile_param_external_source",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param value (https://Dockerfile) is an external source",
 	}}
@@ -25,7 +25,7 @@ test_dockerfile_param_https_source if {
 
 test_dockerfile_param_http_source if {
 	expected := {{
-		"code": "dockerfile_param_external_source",
+		"code": "buildah_build_task.dockerfile_param_external_source",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param value (http://Dockerfile) is an external source",
 	}}
@@ -36,7 +36,7 @@ test_dockerfile_param_http_source if {
 
 test_dockerfile_param_not_included if {
 	expected := {{
-		"code": "dockerfile_param_not_included",
+		"code": "buildah_build_task.dockerfile_param_not_included",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "DOCKERFILE param is not included in the task",
 	}}

--- a/policy/release/hermetic_build_task_test.rego
+++ b/policy/release/hermetic_build_task_test.rego
@@ -12,7 +12,7 @@ test_hermetic_build if {
 
 test_not_hermetic_build if {
 	expected := {{
-		"code": "build_task_not_hermetic",
+		"code": "hermetic_build_task.build_task_not_hermetic",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task was not invoked with hermetic parameter",
 	}}

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -11,7 +11,7 @@ test_all_good {
 
 test_has_foreign {
 	attestations := [lib.att_mock_helper_ref(lib.java_sbom_component_count_result_name, {"redhat": 12, "rebuilt": 42, "central": 1}, "java-task-1", bundles.acceptable_bundle_ref)]
-	lib.assert_equal(deny, {{"code": "java_foreign_dependencies", "effective_on": "2022-01-01T00:00:00Z", "msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'"}}) with data["task-bundles"] as bundles.bundle_data
+	lib.assert_equal(deny, {{"code": "java.java_foreign_dependencies", "effective_on": "2022-01-01T00:00:00Z", "msg": "Found Java dependencies from 'central', expecting to find only from 'rebuilt,redhat'"}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as attestations
 }
 

--- a/policy/release/not_useful_test.rego
+++ b/policy/release/not_useful_test.rego
@@ -4,7 +4,7 @@ import data.lib
 
 test_not_useful {
 	lib.assert_equal(deny, {{
-		"code": "bad_day",
+		"code": "not_useful.bad_day",
 		"msg": "It just feels like a bad day to do a release",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}})

--- a/policy/release/slsa_build_build_service_test.rego
+++ b/policy/release/slsa_build_build_service_test.rego
@@ -21,7 +21,7 @@ test_missing_builder_id if {
 	]
 
 	expected := {{
-		"code": "missing_builder_id",
+		"code": "slsa_build_build_service.missing_builder_id",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Builder ID not set in attestation",
 	}}
@@ -32,7 +32,7 @@ test_missing_builder_id if {
 test_unexpected_builder_id if {
 	builder_id := "https://notket.ved/sniahc/2v"
 	expected := {{
-		"code": "unexpected_builder_id",
+		"code": "slsa_build_build_service.unexpected_builder_id",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Builder ID \"https://notket.ved/sniahc/2v\" is unexpected",
 	}}

--- a/policy/release/slsa_build_scripted_build_test.rego
+++ b/policy/release/slsa_build_scripted_build_test.rego
@@ -38,7 +38,7 @@ test_scattered_results if {
 	]
 
 	expected := {{
-		"code": "missing_build_task",
+		"code": "slsa_build_scripted_build.missing_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
 	}}
@@ -58,7 +58,7 @@ test_missing_task_steps if {
 	}]
 
 	expected := {{
-		"code": "empty_build_task",
+		"code": "slsa_build_scripted_build.empty_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task \"buildah\" does not contain any steps",
 	}}
@@ -78,7 +78,7 @@ test_empty_task_steps if {
 	}]
 
 	expected := {{
-		"code": "empty_build_task",
+		"code": "slsa_build_scripted_build.empty_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task \"buildah\" does not contain any steps",
 	}}
@@ -98,7 +98,7 @@ test_unacceptable_bundle if {
 	}]
 
 	expected := {{
-		"code": "missing_build_task",
+		"code": "slsa_build_scripted_build.missing_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
 	}}
@@ -118,7 +118,7 @@ test_results_missing_value_url if {
 	}]
 
 	expected := {{
-		"code": "missing_build_task",
+		"code": "slsa_build_scripted_build.missing_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
 	}}
@@ -138,7 +138,7 @@ test_results_missing_value_digest if {
 	}]
 
 	expected := {{
-		"code": "missing_build_task",
+		"code": "slsa_build_scripted_build.missing_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
 	}}
@@ -158,7 +158,7 @@ test_results_empty_value_url if {
 	}]
 
 	expected := {{
-		"code": "missing_build_task",
+		"code": "slsa_build_scripted_build.missing_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
 	}}
@@ -178,7 +178,7 @@ test_results_empty_value_digest if {
 	}]
 
 	expected := {{
-		"code": "missing_build_task",
+		"code": "slsa_build_scripted_build.missing_build_task",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Build task not found",
 	}}
@@ -198,7 +198,7 @@ test_subject_mismatch if {
 	}]
 
 	expected := {{
-		"code": "subject_build_task_mismatch",
+		"code": "slsa_build_scripted_build.subject_build_task_mismatch",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "The attestation subject, \"some.image/foo:bar@sha256:123\", does not match the build task image, \"some.image/foo:bar@sha256:anotherdigest\"",
 	}}
@@ -264,7 +264,7 @@ test_subject_with_tag_and_digest_mismatch_digest_fails if {
 	}]
 
 	expected := {{
-		"code": "subject_build_task_mismatch",
+		"code": "slsa_build_scripted_build.subject_build_task_mismatch",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "The attestation subject, \"registry.io/repository/image@sha256:unexpected\", does not match the build task image, \"registry.io/repository/image:tag@sha256:digest\"",
 	}}

--- a/policy/release/slsa_provenance_available_test.rego
+++ b/policy/release/slsa_provenance_available_test.rego
@@ -12,7 +12,7 @@ test_expected_predicate_type {
 test_unexpected_predicate_type {
 	attestations := _mock_attestations(["spam"])
 	expected_deny := {{
-		"code": "unexpected_predicate_type",
+		"code": "slsa_provenance_available.unexpected_predicate_type",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "Attestation predicate type \"spam\" is not an expected type (https://slsa.dev/provenance/v0.2)",
 	}}

--- a/policy/release/slsa_source_version_controlled_test.rego
+++ b/policy/release/slsa_source_version_controlled_test.rego
@@ -33,12 +33,12 @@ test_non_git_uri if {
 
 	expected := {
 		{
-			"code": "material_non_git_uri",
+			"code": "slsa_source_version_controlled.material_non_git_uri",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material URI \"ggit+https://example/repo\" is not a git URI",
 		},
 		{
-			"code": "material_non_git_uri",
+			"code": "slsa_source_version_controlled.material_non_git_uri",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material URI \"svn+https://exmaple/other-repo.git\" is not a git URI",
 		},
@@ -68,17 +68,17 @@ test_non_git_commit if {
 
 	expected := {
 		{
-			"code": "material_without_git_commit",
+			"code": "slsa_source_version_controlled.material_without_git_commit",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material digest \"g9ef4c1f9273718b2421b2c076f09786ede5982c\" is not a git commit",
 		},
 		{
-			"code": "material_without_git_commit",
+			"code": "slsa_source_version_controlled.material_without_git_commit",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material digest \"1d2d2f924e986ac86fdf7b36c94bcdf32beec15\" is not a git commit",
 		},
 		{
-			"code": "material_without_git_commit",
+			"code": "slsa_source_version_controlled.material_without_git_commit",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": "Material digest \"36d89a3cadcdf269110757df1074b4ef45fe641ee\" is not a git commit",
 		},
@@ -98,7 +98,7 @@ test_invalid_materials if {
 	]
 
 	expected := {{
-		"code": "missing_materials",
+		"code": "slsa_source_version_controlled.missing_materials",
 		"effective_on": "2022-01-01T00:00:00Z",
 		"msg": "No materials match expected format",
 	}}

--- a/policy/release/step_image_registries_test.rego
+++ b/policy/release/step_image_registries_test.rego
@@ -20,7 +20,7 @@ test_image_registry_valid {
 test_attestation_type_invalid {
 	expected_msg := sprintf("Step 0 in task 'mytask' has disallowed image ref '%s'", [bad_image])
 	lib.assert_equal(deny, {{
-		"code": "disallowed_task_step_image",
+		"code": "step_image_registries.disallowed_task_step_image",
 		"msg": expected_msg,
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_data(bad_image)

--- a/policy/release/tasks_test.rego
+++ b/policy/release/tasks_test.rego
@@ -76,7 +76,7 @@ test_current_equal_latest_also if {
 
 test_no_tasks_present if {
 	expected := {{
-		"code": "tasks_missing",
+		"code": "tasks.tasks_missing",
 		"msg": "No tasks found in PipelineRun attestation",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}
@@ -158,7 +158,7 @@ _missing_tasks_violation(tasks) = errors if {
 	errors := {error |
 		some task in tasks
 		error := {
-			"code": "missing_required_task",
+			"code": "tasks.missing_required_task",
 			"msg": sprintf("Required task %q is missing", [task]),
 			"effective_on": "2022-01-01T00:00:00Z",
 		}
@@ -169,7 +169,7 @@ _missing_tasks_warning(tasks) = warnings if {
 	warnings := {warning |
 		some task in tasks
 		warning := {
-			"code": "missing_future_required_task",
+			"code": "tasks.missing_future_required_task",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": sprintf("Task %q is missing and will be required in the future", [task]),
 		}

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -8,7 +8,7 @@ mock_empty_data := [lib.att_mock_helper_ref("NOT_HACBS_TEST_OUTPUT", {}, "task1"
 
 test_needs_non_empty_data {
 	lib.assert_equal(deny, {{
-		"code": "test_data_missing",
+		"code": "test.test_data_missing",
 		"msg": "No test data found",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as mock_empty_data
@@ -19,7 +19,7 @@ mock_without_results_data := [lib.att_mock_helper_ref(lib.hacbs_test_task_result
 
 test_needs_tests_with_results {
 	lib.assert_equal(deny, {{
-		"code": "test_results_missing",
+		"code": "test.test_results_missing",
 		"msg": "Found tests without results",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -33,7 +33,7 @@ mock_without_results_data_mixed := [
 
 test_needs_tests_with_results_mixed {
 	lib.assert_equal(deny, {{
-		"code": "test_results_missing",
+		"code": "test.test_results_missing",
 		"msg": "Found tests without results",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -52,7 +52,7 @@ mock_a_failing_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name,
 
 test_failure_data {
 	lib.assert_equal(deny, {{
-		"code": "test_result_failures",
+		"code": "test.test_result_failures",
 		"msg": "The following tests did not complete successfully: failed_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -64,7 +64,7 @@ mock_an_errored_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name
 
 test_error_data {
 	lib.assert_equal(deny, {{
-		"code": "test_result_failures",
+		"code": "test.test_result_failures",
 		"msg": "The following tests did not complete successfully: errored_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -76,7 +76,7 @@ mock_mixed_data := array.concat(mock_a_failing_test, mock_an_errored_test)
 
 test_mix_data {
 	lib.assert_equal(deny, {{
-		"code": "test_result_failures",
+		"code": "test.test_result_failures",
 		"msg": "The following tests did not complete successfully: errored_1, failed_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -100,7 +100,7 @@ test_can_skip_by_name {
 		with data.config.policy as {"exclude": ["test:errored_1"], "non_blocking_checks": ["test:failed_1"]}
 
 	lib.assert_equal(deny, {{
-		"code": "test_result_failures",
+		"code": "test.test_result_failures",
 		"msg": "The following tests did not complete successfully: errored_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -109,7 +109,7 @@ test_can_skip_by_name {
 
 	# exclude works the same as non_blocking_checks
 	lib.assert_equal(deny, {{
-		"code": "test_result_failures",
+		"code": "test.test_result_failures",
 		"msg": "The following tests did not complete successfully: errored_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -126,7 +126,7 @@ test_skipped_is_not_deny {
 test_skipped_is_warning {
 	skipped_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_1", bundles.acceptable_bundle_ref)]
 	lib.assert_equal(warn, {{
-		"code": "test_result_skipped",
+		"code": "test.test_result_skipped",
 		"msg": "The following tests were skipped: skipped_1",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -145,14 +145,14 @@ test_mixed_statuses {
 	]
 
 	lib.assert_equal(deny, {{
-		"code": "test_result_failures",
+		"code": "test.test_result_failures",
 		"msg": "The following tests did not complete successfully: error_1, error_2, failure_1, failure_2",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as test_results
 
 	lib.assert_equal(warn, {{
-		"code": "test_result_skipped",
+		"code": "test.test_result_skipped",
 		"msg": "The following tests were skipped: skipped_1, skipped_2",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
@@ -168,17 +168,17 @@ test_unsupported_test_result {
 	]
 
 	lib.assert_equal(deny, {
-		{"code": "test_result_unsupported", "msg": "Test 'error_1' has unsupported result 'EROR'", "effective_on": "2022-01-01T00:00:00Z"},
-		{"code": "test_result_unsupported", "msg": "Test 'failure_1' has unsupported result 'FAIL'", "effective_on": "2022-01-01T00:00:00Z"},
-		{"code": "test_result_unsupported", "msg": "Test 'skipped_1' has unsupported result 'SKIPED'", "effective_on": "2022-01-01T00:00:00Z"},
-		{"code": "test_result_unsupported", "msg": "Test 'success_1' has unsupported result 'SUCESS'", "effective_on": "2022-01-01T00:00:00Z"},
+		{"code": "test.test_result_unsupported", "msg": "Test 'error_1' has unsupported result 'EROR'", "effective_on": "2022-01-01T00:00:00Z"},
+		{"code": "test.test_result_unsupported", "msg": "Test 'failure_1' has unsupported result 'FAIL'", "effective_on": "2022-01-01T00:00:00Z"},
+		{"code": "test.test_result_unsupported", "msg": "Test 'skipped_1' has unsupported result 'SKIPED'", "effective_on": "2022-01-01T00:00:00Z"},
+		{"code": "test.test_result_unsupported", "msg": "Test 'success_1' has unsupported result 'SUCESS'", "effective_on": "2022-01-01T00:00:00Z"},
 	}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as test_results
 }
 
 test_unacceptable_bundle_results {
 	lib.assert_equal(deny, {{
-		"code": "test_data_missing",
+		"code": "test.test_data_missing",
 		"msg": "No test data found",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with input.attestations as [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SUCCESS"}, "task1", "registry.img/unacceptable@sha256:digest")]


### PR DESCRIPTION
Any violation code will now contain the package name followed by the policy rule short name. This helps users more easily determine what should be used in an include/exclude statement.

It also paves the way for moving the include/exclude logic out of rego and into the ec-cli, see https://issues.redhat.com/browse/HACBS-1303

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>