### PR TITLE
Don't try to include `artifacthub-pkg.yml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,10 @@ push-bundle-%:
 	      exit 1; \
 	  cp -r $(POLICY_DIR)/$${d} $${TMP_DIR}/$(POLICY_DIR)/$${d}; \
 	done && \
+	find "$${TMP_DIR}" -name artifacthub-pkg.yml -delete && \
 	\
 	echo "Pushing $(*) policies to $${TARGET}" && \
-	conftest push $${TARGET} $${TMP_DIR} -p $(POLICY_DIR) && \
+	cd "$${TMP_DIR}" && conftest push $${TARGET} && \
 	\
 	rm -rf $${TMP_DIR}
 


### PR DESCRIPTION
`make push-bump` fails with:

```
$ make push-bump
Pushing release policies to quay.io/hacbs-contract/ec-release-policy:git-3ea977a
2023/01/06 20:09:18 pushing bundle to: quay.io/hacbs-contract/ec-release-policy:git-3ea977a
Error: push bundle: building layers: load: load documents: 1 error occurred during loading: policy/release/artifacthub-pkg.yml: merge error
make: *** [Makefile:255: push-bundle-release] Error 1
Error: Process completed with exit code 2.
```

This removes the `artifacthub-pkg.yml` file before attempting to push.

For some reason the `conftest` seemed to also look in the local repository, i.e. regardless of passing in the temp directory as a parameter, to help with that this also `cd`s into the temp directory and runs `conftest push` from there.