### PR TITLE
Add WARNING test result

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -15,6 +15,7 @@ rule_data:
   - FAILURE
   - ERROR
   - SKIPPED
+  - WARNING
   allowed_predicate_types:
   - https://slsa.dev/provenance/v0.2
   allowed_java_component_sources:

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -121,6 +121,27 @@ warn[result] {
 	)
 }
 
+# METADATA
+# title: Some tests returned a warning
+# description: |-
+#   Collects all tests that have their result set to "WARNING".
+# custom:
+#   short_name: test_result_warning
+#   failure_msg: "The following tests returned a warning: %s"
+#
+warn[result] {
+	all_warned = resulted_in({"WARNING"})
+
+	# Don't report if there aren't any
+	count(all_warned) > 0
+
+	short_warned := [f | f := split(all_warned[_], ":")[1]]
+	result := lib.result_helper(
+		rego.metadata.chain(),
+		[concat(", ", short_warned)],
+	)
+}
+
 resulted_in(results) = filtered_by_result {
 	# Collect all tests that have resulted with one of the given
 	# results and convert their name to "test:<name>" format

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -167,7 +167,7 @@ test_mixed_statuses {
 		"code": "test.test_result_skipped",
 		"msg": "The following tests were skipped: skipped_1, skipped_2",
 		"effective_on": "2022-01-01T00:00:00Z",
-	}}, {{
+	}, {
 		"code": "test.test_result_warning",
 		"msg": "The following tests returned a warning: warning_1, warning_2",
 		"effective_on": "2022-01-01T00:00:00Z",

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -163,18 +163,19 @@ test_mixed_statuses {
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as test_results
 
-    lib.assert_equal(warn, {
-			{
-				"code": "test.test_result_skipped",
-				"msg": "The following tests were skipped: skipped_1, skipped_2",
-				"effective_on": "2022-01-01T00:00:00Z",
-			},
-			{
-				"code": "test.test_result_warning",
-				"msg": "The following tests returned a warning: warning_1, warning_2",
-				"effective_on": "2022-01-01T00:00:00Z",
-			},
+	lib.assert_equal(warn, {
+		{
+			"code": "test.test_result_skipped",
+			"msg": "The following tests were skipped: skipped_1, skipped_2",
+			"effective_on": "2022-01-01T00:00:00Z",
+		},
+		{
+			"code": "test.test_result_warning",
+			"msg": "The following tests returned a warning: warning_1, warning_2",
+			"effective_on": "2022-01-01T00:00:00Z",
+		},
 	}) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as test_results
 }
 
 test_unsupported_test_result {

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -133,6 +133,16 @@ test_skipped_is_warning {
 		with input.attestations as skipped_test
 }
 
+test_warning_is_warning {
+	warning_test := [lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "WARNING"}, "warning_1", bundles.acceptable_bundle_ref)]
+	lib.assert_equal(warn, {{
+		"code": "test.test_result_warning",
+		"msg": "The following tests returned a warning: warning_1",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with data["task-bundles"] as bundles.bundle_data
+		with input.attestations as warning_test
+}
+
 test_mixed_statuses {
 	test_results := [
 		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "error_1", bundles.acceptable_bundle_ref),
@@ -141,7 +151,9 @@ test_mixed_statuses {
 		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_1", bundles.acceptable_bundle_ref),
 		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "FAILURE"}, "failure_2", bundles.acceptable_bundle_ref),
 		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "SKIPPED"}, "skipped_2", bundles.acceptable_bundle_ref),
+		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "WARNING"}, "warning_1", bundles.acceptable_bundle_ref),
 		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "ERROR"}, "error_2", bundles.acceptable_bundle_ref),
+		lib.att_mock_helper_ref(lib.hacbs_test_task_result_name, {"result": "WARNING"}, "warning_2", bundles.acceptable_bundle_ref),
 	]
 
 	lib.assert_equal(deny, {{
@@ -154,6 +166,10 @@ test_mixed_statuses {
 	lib.assert_equal(warn, {{
 		"code": "test.test_result_skipped",
 		"msg": "The following tests were skipped: skipped_1, skipped_2",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}, {{
+		"code": "test.test_result_warning",
+		"msg": "The following tests returned a warning: warning_1, warning_2",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as test_results

--- a/policy/release/test_test.rego
+++ b/policy/release/test_test.rego
@@ -163,16 +163,18 @@ test_mixed_statuses {
 	}}) with data["task-bundles"] as bundles.bundle_data
 		with input.attestations as test_results
 
-	lib.assert_equal(warn, {{
-		"code": "test.test_result_skipped",
-		"msg": "The following tests were skipped: skipped_1, skipped_2",
-		"effective_on": "2022-01-01T00:00:00Z",
-	}, {
-		"code": "test.test_result_warning",
-		"msg": "The following tests returned a warning: warning_1, warning_2",
-		"effective_on": "2022-01-01T00:00:00Z",
-	}}) with data["task-bundles"] as bundles.bundle_data
-		with input.attestations as test_results
+    lib.assert_equal(warn, {
+			{
+				"code": "test.test_result_skipped",
+				"msg": "The following tests were skipped: skipped_1, skipped_2",
+				"effective_on": "2022-01-01T00:00:00Z",
+			},
+			{
+				"code": "test.test_result_warning",
+				"msg": "The following tests returned a warning: warning_1, warning_2",
+				"effective_on": "2022-01-01T00:00:00Z",
+			},
+	}) with data["task-bundles"] as bundles.bundle_data
 }
 
 test_unsupported_test_result {


### PR DESCRIPTION
[ADR-0008](https://github.com/redhat-appstudio/book/pull/24) defines five different test result status types -- `SUCCESS`, `FAILURE`, `WARNING`, `SKIPPED` and `ERROR`. There was no policy defined for handling the `WARNING` result type.

Signed-off-by: arewm <arewm@users.noreply.github.com>