### PR TITLE
Upload code coverage to codecov.io

### DIFF
--- a/.github/workflows/pre-merge-ci.yaml
+++ b/.github/workflows/pre-merge-ci.yaml
@@ -24,3 +24,7 @@ jobs:
 
     - name: Run checks
       run: make ci
+
+    - name: Upload test coverage report
+      uses: codecov/codecov-action@v3
+      if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/
 node_modules/
 .cache/
 *.swp
+coverage.json

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ test: ## Run all tests in verbose mode and check coverage
 coverage: ## Show which lines of rego are not covered by tests
 	@opa test $(TEST_FILES) --coverage --format json | jq -r '.files | to_entries | map("\(.key): Uncovered:\(.value.not_covered)") | .[]' | grep -v "Uncovered:null" | cat
 
+.PHONY: coverage-report ## Generates coverage.json in SimpleCov format
+coverage-report: ## Show which lines of rego are not covered by tests
+	@opa test $(TEST_FILES) --coverage --format json | opa eval --format pretty --stdin-input --data hack/simplecov.rego data.simplecov.from_opa > coverage.json
+
 .PHONY: quiet-test
 quiet-test: ## Run all tests in quiet mode and check coverage
 	@opa test $(TEST_FILES)
@@ -146,7 +150,7 @@ fmt-check: ## Check formatting of Rego files
 	@opa fmt . --list --fail >/dev/null 2>&1
 
 .PHONY: ci
-ci: quiet-test opa-check conventions-check fmt-check ## Runs all checks and tests
+ci: coverage-report quiet-test opa-check conventions-check fmt-check ## Runs all checks and tests
 
 #--------------------------------------------------------------------
 

--- a/hack/simplecov.rego
+++ b/hack/simplecov.rego
@@ -1,0 +1,52 @@
+# Copied from https://github.com/open-policy-agent/contrib/tree/main/simplecov/simplecov.rego
+package simplecov
+
+import future.keywords
+
+from_opa := {"coverage": coverage}
+
+coverage[file] = obj if {
+	some file, report in input.files
+	obj := {"lines": lines(report)}
+}
+
+covered_map(report) = cm if {
+	covered := object.get(report, "covered", [])
+	cm := {line: 1 |
+		some item in covered
+		some line in numbers.range(item.start.row, item.end.row)
+	}
+}
+
+not_covered_map(report) = ncm if {
+	not_covered := object.get(report, "not_covered", [])
+	ncm := {line: 0 |
+		some item in not_covered
+		some line in numbers.range(item.start.row, item.end.row)
+	}
+}
+
+lines(report) = lines if {
+	cm := covered_map(report)
+	ncm := not_covered_map(report)
+	keys := sort([line | some line, _ in object.union(cm, ncm)])
+	last := keys[count(keys) - 1]
+
+	lines := [value |
+		some i in numbers.range(1, last)
+		value := to_value(cm, ncm, i)
+	]
+}
+
+to_value(cm, _, line) = 1 if {
+	cm[line]
+}
+
+to_value(_, ncm, line) = 0 if {
+	ncm[line]
+}
+
+to_value(cm, ncm, line) = null if {
+	not cm[line]
+	not ncm[line]
+}


### PR DESCRIPTION
Adds a Make target `coverage-report` that generates `coverage.json` in SimpleCov format using `hack/simplecov.rego` sourced from[1] and uploads it in pre-merge-ci workflow to codecov.io.

[1] https://github.com/open-policy-agent/contrib/tree/main/simplecov