### PR TITLE
Use attachments in documentation

### DIFF
--- a/antora/docs/acceptable_tekton_bundles.yml
+++ b/antora/docs/acceptable_tekton_bundles.yml
@@ -1,1 +1,0 @@
-../../data/acceptable_tekton_bundles.yml

--- a/antora/docs/modules/ROOT/attachments/acceptable_tekton_bundles.yml
+++ b/antora/docs/modules/ROOT/attachments/acceptable_tekton_bundles.yml
@@ -1,0 +1,1 @@
+../../../../../data/acceptable_tekton_bundles.yml

--- a/antora/docs/modules/ROOT/attachments/rule_data.yml
+++ b/antora/docs/modules/ROOT/attachments/rule_data.yml
@@ -1,0 +1,1 @@
+../../../../../data/rule_data.yml

--- a/antora/docs/modules/ROOT/templates/policy_configuration.hbs
+++ b/antora/docs/modules/ROOT/templates/policy_configuration.hbs
@@ -232,7 +232,7 @@ registries is a data value. This type of data is called Rule Data.
 
 In addition to policy rules, the ec-policies git repository also defines values
 for Rule Data, see
-link:https://github.com/hacbs-contract/ec-policies/blob/main/data/rule_data.yml[data/rule_data.yml]
+xref:attachment$rule_data.yml[rule_data.yml]
 . As a user, you can provide a custom data source with modified Rule Data
 allowing the same policy rules to be used to best fit your use cases.
 
@@ -280,9 +280,7 @@ NOTE: If the data source contains policy rules, those will be ignored.
 
 NOTE: If you replace the default data source entirely, you must provide the full set of required data values.
 These are all the values defined in
-link:https://github.com/hacbs-contract/ec-policies/blob/main/data/rule_data.yml[data/rule_data.yml]
-and
-link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
+xref:attachment$rule_data.yml[data/rule_data.yml] and xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml].
 
 NOTE: It's also possible to add an additional data source containing rule data
 defined under the `rule_data_custom` top level key. Data under this key will

--- a/antora/docs/rule_data.yml
+++ b/antora/docs/rule_data.yml
@@ -1,1 +1,0 @@
-../../data/rule_data.yml

--- a/policy/pipeline/task_bundle.rego
+++ b/policy/pipeline/task_bundle.rego
@@ -65,7 +65,7 @@ warn contains result if {
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   is the most recent acceptable one. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
+#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
 #   in this git repository. The meaning of an acceptable bundle is explained in
 #   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
 # custom:
@@ -83,7 +83,7 @@ warn contains result if {
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   are acceptable given the tracked effective_on date. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
+#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
 #   in this git repository. The meaning of an acceptable bundle is explained in
 #   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
 # custom:

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -62,7 +62,7 @@ warn[result] {
 #   Check if the Tekton Bundle used for the Tasks in the attestation
 #   is the most recent acceptable one. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
+#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
 #   in this git repository. The meaning of an acceptable bundle is explained in
 #   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
 # custom:
@@ -80,7 +80,7 @@ warn[result] {
 #   Check if the Tekton Bundle used for the Tasks in the attestation
 #   are acceptable given the tracked effective_on date. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
-#   link:https://github.com/hacbs-contract/ec-policies/blob/main/data/acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
+#   xref:attachment$acceptable_tekton_bundles.yml[data/acceptable_tekton_bundles.yml]
 #   in this git repository. The meaning of an acceptable bundle is explained in
 #   xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles]
 # custom:


### PR DESCRIPTION
This way we can capture the version that was present at the build time, and allow for different versions of the documentation to point to different files or files with varying content.

Ref. https://issues.redhat.com/browse/HACBS-1574