### PR TITLE
Fetch full git history in push bundle workflow

### DIFF
--- a/.github/workflows/push-bundles.yaml
+++ b/.github/workflows/push-bundles.yaml
@@ -6,8 +6,6 @@ on:
     branches:
     - main
     paths:
-    # Todo: We could probably trigger each of the three different
-    # bundle pushes separately to avoid needless rebuild and PR churn
     - policy/**
     - data/**
 
@@ -18,6 +16,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        # So we can see in which commit a bundle's content was
+        # most recently updated
+        fetch-depth: 0
 
     - name: Docker login
       uses: docker/login-action@v2


### PR DESCRIPTION
Otherwise `git log -n1 -- some/dir` always shows the top commit which breaks the test to decide if a bundle push is required.

Also remove an obsolete todo comment.