### PR TITLE
Fix regex to find `acceptable_tekton_bundles.yml`

### DIFF
--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -240,7 +240,7 @@ module.exports.register = function() {
     //
     const yaml = this.require('js-yaml')
 
-    const bundlesFile = helpers.firstFileMatching(content, /^acceptable_tekton_bundles.yml$/)
+    const bundlesFile = helpers.firstFileMatching(content, /\/acceptable_tekton_bundles.yml$/)
     if (!bundlesFile) throw `Unable to find acceptable bundles file: (${__filename})`
     const rawBundlesData = yaml.load(bundlesFile._contents.toString())
     const acceptableBundles = helpers.processBundlesData(rawBundlesData)


### PR DESCRIPTION
Let's not require that `acceptable_tekton_bundles.yml` is placed in the root of the Antora site content, as with the latest change it was placed in `modules/ROOT/attachments/acceptable_tekton_bundles.yml`. Fixes the docs build:

```
[09:26:53.558] FATAL (antora): Unable to find acceptable bundles file: (/home/runner/work/hacbs-contract.github.io/hacbs-contract.github.io/node_modules/@hacbs-contract/ec-policies-antora-extension/index.js)
```