### PR TITLE
Force bundle push with fresh bundle digest

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -13,3 +13,5 @@ rule_data:
   allowed_java_component_sources:
   - redhat
   - rebuilt
+
+# 1

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -46,3 +46,5 @@ rule_data(key_name) := value {
 } else := value {
 	value := []
 }
+
+# 1


### PR DESCRIPTION
It's a long story, but this is a hacky but effective way to ensure a bundle push will be triggered with image digests that are new and unique. If we ever need to do it again we can bump the number.

(Previously I've added some random comment or whitespace change, but I didn't want to keep doing that.)

Related to https://issues.redhat.com/browse/HACBS-1603