### PR TITLE
HACBS-1568 UPDATE links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See also
 [entr]: https://github.com/eradman/entr
 [testing]: https://www.openpolicyagent.org/docs/latest/policy-testing/
 [docs]: https://hacbs-contract.github.io/
-[hacbsdocs]: https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/ec-policies/index.html
+[hacbsdocs]: https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/ec-policies/index.html
 [taskdef]: https://github.com/redhat-appstudio/build-definitions/blob/main/tasks/verify-enterprise-contract.yaml
 [contract]: https://github.com/hacbs-contract
 [appstudio]: https://github.com/redhat-appstudio

--- a/antora/docs/modules/ROOT/pages/index.adoc
+++ b/antora/docs/modules/ROOT/pages/index.adoc
@@ -16,6 +16,7 @@ xref:pipeline_policy.adoc[Pipeline Policy].
 === Additional Documentation
 
 * https://red-hat-hybrid-application-cloud-build-services-documentation.pages.redhat.com/hacbs-documentation/[HACBS Documentation]
+* https://red-hat-stone-soup.pages.redhat.com/stonesoup-documentation/[HACBS Documentation]
 * https://hacbs-contract.github.io/ec-cli/ec-cli/main/ec.html[EC CLI Documentation]
 
 === Code


### PR DESCRIPTION
This commit updates the links to reflect the URLs of the new Stone Soup docs URL.

Signed-off-by: Rob Nester <rnester@redhat.com>