### PR TITLE
Ensure policy bundle always have a unique digest

### DIFF
--- a/.github/workflows/push-bundles.yaml
+++ b/.github/workflows/push-bundles.yaml
@@ -50,5 +50,6 @@ jobs:
           echo "${header}.${payload}.${signature}"
         }
 
+        ENSURE_UNIQUE=1 \
         GITHUB_TOKEN=$(curl -s -X POST -H "Authorization: Bearer $(createJWT)" -H "Accept: application/vnd.github+json" "https://api.github.com/app/installations/${APP_INSTALL_ID}/access_tokens" | jq -r .token) \
         hack/update-bundles.sh

--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -1,5 +1,4 @@
 ---
-
 rule_data:
   allowed_registry_prefixes:
   - registry.access.redhat.com/
@@ -13,5 +12,3 @@ rule_data:
   allowed_java_component_sources:
   - redhat
   - rebuilt
-
-# 2

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -46,5 +46,3 @@ rule_data(key_name) := value {
 } else := value {
 	value := []
 }
-
-# 2


### PR DESCRIPTION
In update-bundles.sh optionally add a timestamp so that the bundle content and hence its digest is always different to all previous bundles when attempting to push a bundle.

It's a workaound to avoid the error described in PROJQUAY-4977 (...which we seem to be hitting sometimes even when the bundle digest should be new, so this patch might not actually be a solution...)

Also:
- Add a dry run option so you can more easily test the logic in the script without actually doing a real push.
- Add the new env var to the github workflow definition.
- Remove the "uniqueness bump number" used previously.