### PR TITLE
Allow manual trigger of bundle push

### DIFF
--- a/.github/workflows/push-bundles.yaml
+++ b/.github/workflows/push-bundles.yaml
@@ -9,6 +9,8 @@ on:
     - policy/**
     - data/**
 
+  workflow_dispatch:
+
 jobs:
   push-policy-bundles:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes, such as when a previous bundle push failed for some reason, you might want to trigger a bundle push manually.