### PR TITLE
Don't rely on the time-descending order of the "required-tasks" data

### DIFF
--- a/policy/lib/array_helpers.rego
+++ b/policy/lib/array_helpers.rego
@@ -1,0 +1,44 @@
+package lib.arrays
+
+import future.keywords.in
+
+_max_int := 9223372036854775807
+
+# Returns true if left is less or equal to right. Comparisson is done by using
+# native comparisson in Rego if both left and right are of the same type, or by
+# comparing their numerical values if they're not. Undefined values are allways
+# less or equal to any other value.
+le(left, right) = is_le {
+	type_name(left) == type_name(right)
+	is_le := left <= right
+} else = is_le {
+	is_le := to_number(left) <= to_number(right)
+}
+
+# Calculates the rank of an object by given key within an array ary. That is,
+# returns number of elements `o` of ary that have `o[key]` less than `obj[key]`
+# for a given object `obj`.
+rank(obj, key, ary) = count(less_or_eq) {
+	less_or_eq := [o |
+		some o in ary
+		left := object.get(o, key, _max_int)
+		right := object.get(obj, key, _max_int)
+		le(left, right)
+	]
+}
+
+# Sorts elements of the array of objects by the the specified key in ascending
+# order. Performs a # N x (N-1) search of an element of `ary` that has the rank
+# corresponding to the indexing variable 1..N.
+sort_by(key, ary) = [sorted |
+	some i in numbers.range(1, count(ary))
+
+	ranked := [o |
+		some o in ary
+
+		i == rank(o, key, ary)
+	]
+
+	count(ranked) > 0 # skip gaps in ranking that happen when two or more objects have the same rank
+	sorted := ranked[_] # flatten any objects with the same rank
+]

--- a/policy/lib/array_helpers_test.rego
+++ b/policy/lib/array_helpers_test.rego
@@ -1,0 +1,43 @@
+package lib.arrays
+
+import data.lib
+
+ary := [{"x": 1, "z": "X"}, {"x": 2}, {"x": 6, "y": "B"}, {"x": 1, "z": "X"}, {"x": -1}]
+
+test_rank {
+	lib.assert_equal(4, rank({"x": 4, "y": "A"}, "x", ary))
+	lib.assert_equal(1, rank({"x": -1}, "x", ary))
+	lib.assert_equal(0, rank({"x": -2}, "x", ary))
+	lib.assert_equal(5, rank({"x": 7}, "x", ary))
+	lib.assert_equal(count(ary), rank({}, "x", ary))
+	lib.assert_equal(count(ary), rank({}, "w", ary))
+}
+
+test_sort_by {
+	lib.assert_equal([{"x": -1}, {"x": 1, "z": "X"}, {"x": 1, "z": "X"}, {"x": 2}, {"x": 6, "y": "B"}], sort_by("x", ary))
+	lib.assert_equal([{"x": 6, "y": "B"}, {"x": 1, "z": "X"}, {"x": 2}, {"x": 1, "z": "X"}, {"x": -1}], sort_by("y", ary))
+}
+
+test_sort_by_mixed_types {
+	lib.assert_equal([{"x": 0}, {"x": "1"}, {"x": 2.0}], sort_by("x", [{"x": "1"}, {"x": 0}, {"x": 2.0}]))
+}
+
+test_le {
+	le(0, 0)
+	le("A", "A")
+	le(1, "1")
+	le("2", 2)
+	le(3.0, 3.0)
+	le("4.0", 4.0)
+	le(5.0, "5.0")
+
+	le(0, 1)
+	le("A", "B")
+	le("0", 1)
+	le(0, "1")
+
+	not le(1, 0)
+	not le("B", "A")
+	not le(1, "0")
+	not le("1", 0)
+}

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -15,7 +15,7 @@ missing_required_tasks_data if {
 # The latest set of required tasks. Tasks here are not required right now
 # but will be required in the future.
 latest_required_tasks contains task if {
-	some task in data["required-tasks"][0].tasks
+	some task in time.newest(data["required-tasks"]).tasks
 }
 
 # The set of required tasks that are required right now.

--- a/policy/lib/time.rego
+++ b/policy/lib/time.rego
@@ -2,6 +2,8 @@ package lib.time
 
 import future.keywords.in
 
+import data.lib.arrays
+
 # A default value in the past. Could be whatever but beware you'll have to
 # update a bunch of tests if you change it.
 #
@@ -70,3 +72,11 @@ future_items(items) = some_items {
 acceptable_items(items) = some_items {
 	some_items := array.concat(future_items(items), [most_current(items)])
 } else = future_items(items)
+
+# newest returns the newest item by `effective_on`. Assumes same date format and
+# time-zone for `effective_on` field.
+newest(items) = item {
+	ordered := arrays.sort_by("effective_on", items)
+
+	item := ordered[count(ordered) - 1]
+}

--- a/policy/lib/time.rego
+++ b/policy/lib/time.rego
@@ -52,7 +52,7 @@ most_current(items) = item {
 		not time.parse_rfc3339_ns(i.effective_on) > effective_current_time_ns
 	]
 
-	item := current[0]
+	item := newest(current)
 }
 
 # future_items returns a filtered list of the given items where each item has

--- a/policy/lib/time_test.rego
+++ b/policy/lib/time_test.rego
@@ -134,3 +134,11 @@ test_acceptable_items {
 	# Return empty list when input is an empty list
 	lib.assert_equal(future_items([]), [])
 }
+
+test_newest {
+	lib.assert_equal({"effective_on": "2262-04-11T00:00:00Z"}, newest([
+		{"effective_on": "2199-01-01T00:00:00Z"},
+		{"effective_on": "2262-04-11T00:00:00Z"},
+		{"effective_on": "2099-01-01T00:00:00Z"},
+	]))
+}


### PR DESCRIPTION
[Add sort_by and rank functions](https://github.com/hacbs-contract/ec-policies/commit/2bba5dea9bdc24845d08ca173b0c1d72670d32d6)

Adds `lib.arrays` package with `sort_by` and `rank` functions.

[Add time.newest function](https://github.com/hacbs-contract/ec-policies/commit/bfb9cdbf689c6bcb960608fddc17fdea70662dda)

[Use the newest task instead of first by order](https://github.com/hacbs-contract/ec-policies/commit/7de9ca9806b5e8bb9846e4df0af01b49191b19c5)

Ref. https://issues.redhat.com/browse/HACBS-1507