### PR TITLE
Remove `origin: "dynamic"` from catalog entries

### DIFF
--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -206,9 +206,7 @@ const helpers = {
         abspath,
         basename,
         stem,
-        extname: '.adoc',
-        // Related to the "Edit this page" link created by Antora
-        origin: 'dynamic',
+        extname: '.adoc'
       }
     }
   },


### PR DESCRIPTION
We can leave the `origin` as `undefined`, otherwise Antora when logging tries to deconstruct the `origin` as an object which is not possible for a fixed string `"dynamic"`.
The intent was to not show the `Edit this page` link for generated content, leaving `origin` as `undefined` accomplishes the same.