### PR TITLE
Use single promise with opa-inspect-js

### DIFF
--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -225,8 +225,7 @@ module.exports.register = function() {
     // Extract annotations from the rego files
     //
     const regoFiles = helpers.filesMatching(content, /^policy\/.*(?!_test)\.rego$/)
-    const opaInspectPromises = regoFiles.map(f => opa.inspect(f.path, f._contents.toString()))
-    const rawAnnotationsData = await Promise.all(opaInspectPromises).then(a => a.flat())
+    const rawAnnotationsData = await opa.inspect(regoFiles)
 
     // Prepare annotation data for use in the templates
     const pipelineAnnotations = helpers.processAnnotationsData(rawAnnotationsData, "policy.pipeline")

--- a/antora/ec-policies-antora-extension/package-lock.json
+++ b/antora/ec-policies-antora-extension/package-lock.json
@@ -9,16 +9,16 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@zregvart/opa-inspect": "latest"
+        "@zregvart/opa-inspect": "^0.48.0-0875ed2"
       },
       "engines": {
         "node": "18"
       }
     },
     "node_modules/@zregvart/opa-inspect": {
-      "version": "0.48.0-5975603",
-      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.48.0-5975603.tgz",
-      "integrity": "sha512-ASw80qtoE2eH0eGkt3XHhaWtGCKCaCwbGobxQMPlUuy+zYBYkoC9VQN8baLU0J+3R9Wri7Zhn3/ZISKgx1NaFQ==",
+      "version": "0.48.0-0875ed2",
+      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.48.0-0875ed2.tgz",
+      "integrity": "sha512-feTNvPld3IQSDVwRw6JnX41zN/hAWxjJm42P58G/beHlzpUVlnFwQj1twHXDmh0Y4By6sAu9DMLVw3dLdesv8g==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "@zregvart/opa-inspect": {
-      "version": "0.48.0-5975603",
-      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.48.0-5975603.tgz",
-      "integrity": "sha512-ASw80qtoE2eH0eGkt3XHhaWtGCKCaCwbGobxQMPlUuy+zYBYkoC9VQN8baLU0J+3R9Wri7Zhn3/ZISKgx1NaFQ=="
+      "version": "0.48.0-0875ed2",
+      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.48.0-0875ed2.tgz",
+      "integrity": "sha512-feTNvPld3IQSDVwRw6JnX41zN/hAWxjJm42P58G/beHlzpUVlnFwQj1twHXDmh0Y4By6sAu9DMLVw3dLdesv8g=="
     }
   }
 }


### PR DESCRIPTION
Multiple promises end up creating multiple event listeners which might not all get unregistered on node process exit. This uses the `inspect` function from opa-inspect-js that accepts multiple Vynl file objects so a single promise ends up being used.