### PR TITLE
Make rule anchors unique

### DIFF
--- a/antora/docs/modules/ROOT/templates/_rules.hbs
+++ b/antora/docs/modules/ROOT/templates/_rules.hbs
@@ -12,8 +12,8 @@
 {{! Loop over each rule in this package }}
 {{#each .}}
 
-[#{{ shortName }}]
-=== link:#{{ shortName }}[{{ title }}]
+[#{{ anchor }}]
+=== link:#{{ anchor }}[{{ title }}]
 
 {{{ description }}}
 

--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -114,6 +114,7 @@ const helpers = {
           const title = a.annotations.title
           const description = a.annotations.description
           const shortName = a.annotations.custom.short_name
+          const anchor = `${a.path.slice(1).map(e => e.value).join('_')}_${shortName}`
           const warningOrFailure = isWarn ? "warning" : "failure"
           const failureMsg = a.annotations.custom.failure_msg
           const effectiveOn = a.annotations.custom.effective_on
@@ -137,12 +138,12 @@ const helpers = {
             shortName: packageShortName,
             fullName: packagePath,
             title: pkgAnnotation.title || hbsHelpers.toTitle(packageShortName),
-            description: pkgAnnotation.description || ""
+            description: pkgAnnotation.description || "",
           }
 
           output.push({
             fullPath, packagePath, packageInfo,
-            shortName, title, description, ruleData, warningOrFailure,
+            shortName, title, description, anchor, ruleData, warningOrFailure,
             failureMsg, effectiveOn, file, row
           })
         }


### PR DESCRIPTION
Prepend parts of the package, namely type (release, pipeline) and package name to the rule short name and form an `anchor` property that is used to make sure that the ids/anchors point to unique values.