### PR TITLE
REMOVE rule annotation processing code for docs

### DIFF
--- a/antora/docs/modules/ROOT/templates/_rules.hbs
+++ b/antora/docs/modules/ROOT/templates/_rules.hbs
@@ -17,17 +17,6 @@
 
 {{{ description }}}
 
-{{#each ruleData}}
-The {{ toWords @key }} are:
-
-----
-{{#each .}}
-{{ . }}
-{{/each}}
-----
-
-{{/each}}
-
 * Rule type: [rule-type-indicator {{ warningOrFailure }}]#{{ toUpper warningOrFailure }}#
 * {{ toTitle warningOrFailure }} message: `{{ failureMsg }}`
 * Code: `{{ shortName }}`

--- a/antora/ec-policies-antora-extension/index.js
+++ b/antora/ec-policies-antora-extension/index.js
@@ -129,12 +129,6 @@ const helpers = {
           const packagePath = helpers.toDottedPath(a.path.slice(1, a.path.length-1))
           const pkgAnnotation = packageAnnotations[packagePath] || {}
 
-          // If there is some package-scoped rule data then merge it in to the rule-scoped rule data
-          var ruleData = a.annotations.custom.rule_data
-          if (pkgAnnotation.custom && pkgAnnotation.custom[shortName] && pkgAnnotation.custom[shortName].rule_data) {
-            ruleData = {...ruleData, ...pkgAnnotation.custom[shortName].rule_data}
-          }
-
           // Also prepare some info about the package
           // (It's the same for every rule in a package, so it's not efficient to
           // redo this for every rule, but I don't think it will matter.)
@@ -147,7 +141,7 @@ const helpers = {
 
           output.push({
             fullPath, packagePath, packageInfo,
-            shortName, title, description, anchor, ruleData, warningOrFailure,
+            shortName, title, description, anchor, warningOrFailure,
             failureMsg, effectiveOn, file, row
           })
         }


### PR DESCRIPTION
Removed rule annotation processing code from the Antora extention.

Signed-off-by: Rob Nester <rnester@redhat.com>