### PR TITLE
update required pipeline tasks to use pipeline-required-tasks from acceptable bundles

### DIFF
--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -10,16 +10,16 @@ import data.lib.time
 pipeline_label := "pipelines.openshift.io/runtime"
 
 latest_required_pipeline_tasks(pipeline) := pipeline_tasks if {
-    pipeline_data := required_task_list_exists(pipeline)
+    pipeline_data := required_task_list(pipeline)
 	pipeline_tasks := time.newest(pipeline_data).tasks
 }
 
 current_required_pipeline_tasks(pipeline) := pipeline_tasks if {
-    pipeline_data := required_task_list_exists(pipeline)
+    pipeline_data := required_task_list(pipeline)
     pipeline_tasks := time.most_current(pipeline_data).tasks
 }
 
-required_task_list_exists(pipeline) := pipeline_data {
+required_task_list(pipeline) := pipeline_data {
     pipeline_selector := pipeline_label_selector(pipeline, pipeline_label)
     pipeline_data := data["pipeline-required-tasks"][pipeline_selector]
 }

--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -10,18 +10,18 @@ import data.lib.time
 pipeline_label := "pipelines.openshift.io/runtime"
 
 latest_required_pipeline_tasks(pipeline) := pipeline_tasks if {
-    pipeline_data := required_task_list(pipeline)
+	pipeline_data := required_task_list(pipeline)
 	pipeline_tasks := time.newest(pipeline_data).tasks
 }
 
 current_required_pipeline_tasks(pipeline) := pipeline_tasks if {
-    pipeline_data := required_task_list(pipeline)
-    pipeline_tasks := time.most_current(pipeline_data).tasks
+	pipeline_data := required_task_list(pipeline)
+	pipeline_tasks := time.most_current(pipeline_data).tasks
 }
 
-required_task_list(pipeline) := pipeline_data {
-    pipeline_selector := pipeline_label_selector(pipeline, pipeline_label)
-    pipeline_data := data["pipeline-required-tasks"][pipeline_selector]
+required_task_list(pipeline) := pipeline_data if {
+	pipeline_selector := pipeline_label_selector(pipeline, pipeline_label)
+	pipeline_data := data["pipeline-required-tasks"][pipeline_selector]
 }
 
 pipeline_label_selector(pipeline, selector) := value if {
@@ -30,5 +30,5 @@ pipeline_label_selector(pipeline, selector) := value if {
 }
 
 pipeline_name := name if {
-    name := input.metadata.name
+	name := input.metadata.name
 }

--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -1,0 +1,34 @@
+package lib.tkn
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.lib.refs
+import data.lib.time
+
+pipeline_label := "pipelines.openshift.io/runtime"
+
+latest_required_pipeline_tasks(pipeline) := pipeline_tasks if {
+    pipeline_data := required_task_list_exists(pipeline)
+	pipeline_tasks := time.newest(pipeline_data).tasks
+}
+
+current_required_pipeline_tasks(pipeline) := pipeline_tasks if {
+    pipeline_data := required_task_list_exists(pipeline)
+    pipeline_tasks := time.most_current(pipeline_data).tasks
+}
+
+required_task_list_exists(pipeline) := pipeline_data {
+    pipeline_selector := pipeline_label_selector(pipeline, pipeline_label)
+    pipeline_data := data["pipeline-required-tasks"][pipeline_selector]
+}
+
+pipeline_label_selector(pipeline, selector) := value if {
+	some label, value in pipeline.metadata.labels
+	label == selector
+}
+
+pipeline_name := name if {
+    name := input.metadata.name
+}

--- a/policy/lib/tekton/pipeline.rego
+++ b/policy/lib/tekton/pipeline.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.lib.refs
 import data.lib.time
 
 pipeline_label := "pipelines.openshift.io/runtime"

--- a/policy/lib/tekton/task.rego
+++ b/policy/lib/tekton/task.rego
@@ -13,13 +13,29 @@ missing_required_tasks_data if {
 
 # The latest set of required tasks. Tasks here are not required right now
 # but will be required in the future.
-latest_required_tasks contains task if {
+latest_required_default_tasks contains task if {
 	some task in time.newest(data["required-tasks"]).tasks
 }
 
 # The set of required tasks that are required right now.
-current_required_tasks contains task if {
+current_required_default_tasks contains task if {
 	some task in time.most_current(data["required-tasks"]).tasks
+}
+
+# get the future tasks that are pipeline specific. If none exists
+# get the default list
+latest_required_tasks := task_data if {
+	task_data := latest_required_pipeline_tasks(input)
+} else := task_data if {
+	task_data := latest_required_default_tasks
+}
+
+# get the current tasks that are pipeline specific. If none exists
+# get the default list
+current_required_tasks := task_data if {
+	task_data := current_required_pipeline_tasks(input)
+} else := task_data if {
+	task_data := current_required_default_tasks
 }
 
 # tasks returns the set of tasks found in the object.

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -28,50 +28,18 @@ deny contains result if {
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 
-# # METADATA
-# # title: Missing required pipeline tasks
-# # description: |-
-# #   This policy enforces that the required set of tasks are included
-# #   in the Pipeline definition.
-# # custom:
-# #   short_name: missing_required_pipeline_task
-# #   failure_msg: Required task %q is missing
-# deny contains result if {
-# 	count(tkn.tasks(input)) > 0
-# 	required_pipeline_tasks := current_required_tasks(input)
-# 	some missing_required_task in _missing_tasks(required_pipeline_tasks)
-# 	missing_required_task in required_pipeline_tasks
-# 	missing_required_task in latest_required_tasks(input)
-# 	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
-# }
-
 # METADATA
-# title: Missing required pipeline tasks warning
+# title: Missing required pipeline tasks
 # description: |-
 #   This policy warns if a task list does not exist in the acceptable_bundles.yaml file
 # custom:
-#   short_name: missing_required_pipeline_task_warning
+#   short_name: missing_required_pipeline_task
 #   failure_msg: Required tasks do not exist for pipeline %q
 warn contains result if {
 	count(tkn.tasks(input)) > 0
 	not tkn.current_required_pipeline_tasks(input)
 	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_name])
 }
-
-# # METADATA
-# # title: Missing future required pipeline tasks
-# # description: |-
-# #   This policy warns when a task that will be required in the future
-# #   was not included in the Pipeline definition.
-# # custom:
-# #   short_name: missing_future_required_pipeline_task
-# #   failure_msg: Task %q is missing and will be required in the future
-# warn contains result if {
-# 	count(tkn.tasks(input)) > 0
-# 	required_pipeline_tasks := tkn.latest_required_pipeline_tasks(input)
-# 	some missing_required_task in _missing_tasks(required_pipeline_tasks)
-# 	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
-# }
 
 # METADATA
 # title: Missing required task

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -121,6 +121,7 @@ warn contains result if {
 #   failure_msg: Missing required task-bundles data
 deny contains result if {
 	tkn.missing_required_tasks_data
+	not tkn.required_task_list(input)
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -28,50 +28,50 @@ deny contains result if {
 	result := lib.result_helper(rego.metadata.chain(), [])
 }
 
-# METADATA
-# title: Missing required specific pipeline tasks
-# description: |-
-#   This policy enforces that the required set of tasks are included
-#   in the Pipeline definition.
-# custom:
-#   short_name: missing_required_pipeline_task
-#   failure_msg: Required task %q is missing
-deny contains result if {
-	count(tkn.tasks(input)) > 0
-	required_pipeline_tasks := tkn.current_required_pipeline_tasks(input)
-	some missing_required_task in _missing_tasks(required_pipeline_tasks)
-	missing_required_task in required_pipeline_tasks
-	missing_required_task in tkn.latest_required_pipeline_tasks(input)
-	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
-}
+# # METADATA
+# # title: Missing required pipeline tasks
+# # description: |-
+# #   This policy enforces that the required set of tasks are included
+# #   in the Pipeline definition.
+# # custom:
+# #   short_name: missing_required_pipeline_task
+# #   failure_msg: Required task %q is missing
+# deny contains result if {
+# 	count(tkn.tasks(input)) > 0
+# 	required_pipeline_tasks := current_required_tasks(input)
+# 	some missing_required_task in _missing_tasks(required_pipeline_tasks)
+# 	missing_required_task in required_pipeline_tasks
+# 	missing_required_task in latest_required_tasks(input)
+# 	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
+# }
 
 # METADATA
 # title: Missing required pipeline tasks warning
 # description: |-
-#   This policy warns if a specific task list does not exist in the acceptable_bundles.yaml file
+#   This policy warns if a task list does not exist in the acceptable_bundles.yaml file
 # custom:
 #   short_name: missing_required_pipeline_task_warning
-#   failure_msg: Specific required tasks do not exist for pipeline %q
+#   failure_msg: Required tasks do not exist for pipeline %q
 warn contains result if {
 	count(tkn.tasks(input)) > 0
 	not tkn.current_required_pipeline_tasks(input)
 	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_name])
 }
 
-# METADATA
-# title: Missing future required specific pipeline tasks
-# description: |-
-#   This policy warns when a task that will be required in the future
-#   was not included in the Pipeline definition.
-# custom:
-#   short_name: missing_future_required_pipeline_task
-#   failure_msg: Task %q is missing and will be required in the future
-warn contains result if {
-	count(tkn.tasks(input)) > 0
-	required_pipeline_tasks := tkn.latest_required_pipeline_tasks(input)
-	some missing_required_task in _missing_tasks(required_pipeline_tasks)
-	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
-}
+# # METADATA
+# # title: Missing future required pipeline tasks
+# # description: |-
+# #   This policy warns when a task that will be required in the future
+# #   was not included in the Pipeline definition.
+# # custom:
+# #   short_name: missing_future_required_pipeline_task
+# #   failure_msg: Task %q is missing and will be required in the future
+# warn contains result if {
+# 	count(tkn.tasks(input)) > 0
+# 	required_pipeline_tasks := tkn.latest_required_pipeline_tasks(input)
+# 	some missing_required_task in _missing_tasks(required_pipeline_tasks)
+# 	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
+# }
 
 # METADATA
 # title: Missing required task
@@ -83,8 +83,6 @@ warn contains result if {
 #   failure_msg: Required task %q is missing
 deny contains result if {
 	count(tkn.tasks(input)) > 0
-	# Check if there is a specific pipeline task list
-	not tkn.current_required_pipeline_tasks(input)
 	# Get missing tasks by comparing with the default required task list
 	some required_task in _missing_tasks(tkn.current_required_tasks)
 
@@ -103,8 +101,6 @@ deny contains result if {
 #   failure_msg: Task %q is missing and will be required in the future
 warn contains result if {
 	count(tkn.tasks(input)) > 0
-	# Check if there is a specific pipeline task list
-	not tkn.latest_required_pipeline_tasks(input)
 	# Get missing tasks by comparing with the default required task list
 	some required_task in _missing_tasks(tkn.latest_required_tasks)
 

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -29,6 +29,51 @@ deny contains result if {
 }
 
 # METADATA
+# title: Missing required specific pipeline tasks
+# description: |-
+#   This policy enforces that the required set of tasks are included
+#   in the Pipeline definition.
+# custom:
+#   short_name: missing_required_pipeline_task
+#   failure_msg: Required task %q is missing
+deny contains result if {
+	count(tkn.tasks(input)) > 0
+	required_pipeline_tasks := tkn.current_required_pipeline_tasks(input)
+	some missing_required_task in _missing_tasks(required_pipeline_tasks)
+	missing_required_task in required_pipeline_tasks
+	missing_required_task in tkn.latest_required_pipeline_tasks(input)
+	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
+}
+
+# METADATA
+# title: Missing required pipeline tasks warning
+# description: |-
+#   This policy warns if a specific task list does not exist in the acceptable_bundles.yaml file
+# custom:
+#   short_name: missing_required_pipeline_task_warning
+#   failure_msg: Specific required tasks do not exist for pipeline %q
+warn contains result if {
+	count(tkn.tasks(input)) > 0
+	not tkn.current_required_pipeline_tasks(input)
+	result := lib.result_helper(rego.metadata.chain(), [tkn.pipeline_name])
+}
+
+# METADATA
+# title: Missing future required specific pipeline tasks
+# description: |-
+#   This policy warns when a task that will be required in the future
+#   was not included in the Pipeline definition.
+# custom:
+#   short_name: missing_future_required_pipeline_task
+#   failure_msg: Task %q is missing and will be required in the future
+warn contains result if {
+	count(tkn.tasks(input)) > 0
+	required_pipeline_tasks := tkn.latest_required_pipeline_tasks(input)
+	some missing_required_task in _missing_tasks(required_pipeline_tasks)
+	result := lib.result_helper(rego.metadata.chain(), [missing_required_task])
+}
+
+# METADATA
 # title: Missing required task
 # description: |-
 #   This policy enforces that the required set of tasks are included
@@ -38,6 +83,9 @@ deny contains result if {
 #   failure_msg: Required task %q is missing
 deny contains result if {
 	count(tkn.tasks(input)) > 0
+	# Check if there is a specific pipeline task list
+	not tkn.current_required_pipeline_tasks(input)
+	# Get missing tasks by comparing with the default required task list
 	some required_task in _missing_tasks(tkn.current_required_tasks)
 
 	# Don't report an error if a task is required now, but not in the future
@@ -55,6 +103,9 @@ deny contains result if {
 #   failure_msg: Task %q is missing and will be required in the future
 warn contains result if {
 	count(tkn.tasks(input)) > 0
+	# Check if there is a specific pipeline task list
+	not tkn.latest_required_pipeline_tasks(input)
+	# Get missing tasks by comparing with the default required task list
 	some required_task in _missing_tasks(tkn.latest_required_tasks)
 
 	# If the required_task is also part of the current_required_tasks, do
@@ -76,7 +127,7 @@ deny contains result if {
 }
 
 # _missing_tasks returns a set of task names that are in the given
-# required_tasks, but not in the PipelineRun attestation.
+# required_tasks, but not in the pipeline definition.
 _missing_tasks(required_tasks) := tasks if {
 	tasks := {task |
 		some task in required_tasks

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -83,6 +83,7 @@ warn contains result if {
 #   failure_msg: Required task %q is missing
 deny contains result if {
 	count(tkn.tasks(input)) > 0
+
 	# Get missing tasks by comparing with the default required task list
 	some required_task in _missing_tasks(tkn.current_required_tasks)
 
@@ -101,6 +102,7 @@ deny contains result if {
 #   failure_msg: Task %q is missing and will be required in the future
 warn contains result if {
 	count(tkn.tasks(input)) > 0
+
 	# Get missing tasks by comparing with the default required task list
 	some required_task in _missing_tasks(tkn.latest_required_tasks)
 

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -36,7 +36,7 @@ test_future_required_tasks_met if {
 }
 
 test_future_required_tasks_not_met if {
-	missing_tasks := {"buildah"}
+	missing_tasks := {"buildah-future"}
 	pipeline := _pipeline_with_tasks_and_label(_expected_future_required_tasks - missing_tasks, [], [])
 
 	expected := _missing_tasks_warning(missing_tasks)
@@ -53,7 +53,7 @@ test_extra_tasks_ignored if {
 test_missing_pipeline_label if {
 	expected := {{
 		"code": "required_tasks.missing_required_pipeline_task_warning",
-		"msg": "Specific required tasks do not exist for pipeline \"fbc\"",
+		"msg": "Required tasks do not exist for pipeline \"fbc\"",
 		"effective_on": "2022-01-01T00:00:00Z"
 	}}
 	pipeline := _pipeline_with_tasks(_expected_required_tasks, [], [])
@@ -226,7 +226,7 @@ _missing_tasks_violation(tasks) = errors if {
 	errors := {error |
 		some task in tasks
 		error := {
-			"code": "required_tasks.missing_required_pipeline_task",
+			"code": "required_tasks.missing_required_task",
 			"msg": sprintf("Required task %q is missing", [task]),
 			"effective_on": "2022-01-01T00:00:00Z",
 		}
@@ -245,22 +245,11 @@ _missing_default_tasks_violation(tasks) = errors if {
 	}
 }
 
-_missing_pipeline_tasks_violation(tasks) = errors if {
-	errors := {error |
-		some task in tasks
-		error := {
-			"code": "required_tasks.missing_required_pipeline_task",
-			"msg": sprintf("Required task %q is missing", [task]),
-			"effective_on": "2022-01-01T00:00:00Z",
-		}
-	}
-}
-
 _missing_tasks_warning(tasks) = warnings if {
 	warnings := {warning |
 		some task in tasks
 		warning := {
-			"code": "required_tasks.missing_future_required_pipeline_task",
+			"code": "required_tasks.missing_future_required_task",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": sprintf("Task %q is missing and will be required in the future", [task]),
 			"term": task,
@@ -273,7 +262,7 @@ _missing_pipeline_tasks_warning(name) = warnings if {
 		warning := {
 			"code": "required_tasks.missing_required_pipeline_task_warning",
 			"effective_on": "2022-01-01T00:00:00Z",
-			"msg": sprintf("Specific required tasks do not exist for pipeline %q", [name]),
+			"msg": sprintf("Required tasks do not exist for pipeline %q", [name]),
 		}
 	}
 }
@@ -295,6 +284,7 @@ _expected_required_tasks := {
 _expected_future_required_tasks := {
 	"git-clone",
 	"buildah",
+	"buildah-future",
 	"conftest-clair",
 	"sanity-label-check[POLICY_NAMESPACE=required_checks]",
 	"sanity-label-check[POLICY_NAMESPACE=optional_checks]",

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -57,7 +57,6 @@ test_missing_pipeline_label if {
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}
 	pipeline := _pipeline_with_tasks(_expected_required_tasks, [], [])
-	expected_denies := _missing_tasks_violation(_expected_future_required_tasks - _expected_required_tasks)
 	lib.assert_equal(expected, warn) with data["pipeline-required-tasks"] as _time_based_pipeline_required_tasks
 		with input as pipeline
 }
@@ -170,6 +169,18 @@ test_parameterized if {
 
 	expected := _missing_default_tasks_violation({"sanity-label-check[POLICY_NAMESPACE=required_checks]"})
 	lib.assert_equal(expected, deny) with data["required-tasks"] as _time_based_required_tasks
+		with input as pipeline
+}
+
+test_missing_required_tasks_data if {
+	pipeline := _pipeline_with_tasks_and_label(_expected_required_tasks, [], [])
+	expected := {{
+		"code": "required_tasks.missing_required_data",
+		"effective_on": "2022-01-01T00:00:00Z",
+		"msg": "Missing required task-bundles data",
+	}}
+	lib.assert_equal(expected, deny) with data["required-tasks"] as []
+		with data["pipeline-required-tasks"] as {}
 		with input as pipeline
 }
 

--- a/policy/pipeline/required_tasks_test.rego
+++ b/policy/pipeline/required_tasks_test.rego
@@ -52,7 +52,7 @@ test_extra_tasks_ignored if {
 
 test_missing_pipeline_label if {
 	expected := {{
-		"code": "required_tasks.missing_required_pipeline_task_warning",
+		"code": "required_tasks.missing_required_pipeline_task",
 		"msg": "Required tasks do not exist for pipeline \"fbc\"",
 		"effective_on": "2022-01-01T00:00:00Z",
 	}}
@@ -265,7 +265,7 @@ _missing_tasks_warning(tasks) = warnings if {
 _missing_pipeline_tasks_warning(name) = warnings if {
 	warnings := {warning |
 		warning := {
-			"code": "required_tasks.missing_required_pipeline_task_warning",
+			"code": "required_tasks.missing_required_pipeline_task",
 			"effective_on": "2022-01-01T00:00:00Z",
 			"msg": sprintf("Required tasks do not exist for pipeline %q", [name]),
 		}


### PR DESCRIPTION
update required pipeline tasks to look for tasks in `pipeline-required-tasks` key in acceptable bundles. If not found, look at the `required-tasks`.