### PR TITLE
Trigger docs build for AppStudio docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,6 +9,13 @@ name: docs
 jobs:
   website_update:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - APP_INSTALL_ID: 29980719
+            REPOSITORY: hacbs-contract/hacbs-contract.github.io
+          - APP_INSTALL_ID: 32872589
+            REPOSITORY: redhat-appstudio/docs.stonesoup.io
     steps:
       - name: Trigger website update
         env:
@@ -22,5 +29,5 @@ jobs:
             echo "${header}.${payload}.${signature}"
           }
 
-          GITHUB_TOKEN=$(curl -s -X POST -H "Authorization: Bearer $(createJWT)" -H "Accept: application/vnd.github+json" https://api.github.com/app/installations/29980719/access_tokens | jq -r .token) \
-          gh api repos/hacbs-contract/hacbs-contract.github.io/dispatches -X POST --input <(echo '{"event_type":"update","client_payload":{}}')
+          GITHUB_TOKEN=$(curl -s -X POST -H "Authorization: Bearer $(createJWT)" -H "Accept: application/vnd.github+json" https://api.github.com/app/installations/${{ matrix.APP_INSTALL_ID }}/access_tokens | jq -r .token) \
+          gh api repos/${{ matrix.REPOSITORY }}/dispatches -X POST --input <(echo '{"event_type":"update","client_payload":{}}')


### PR DESCRIPTION
This extends the docs workflow to trigger the documentation build in redhat-appstudio/docs.stonesoup.io and
hacbs-contract/hacbs-contract.github.io repositories.