### PR TITLE
Ensure infra-deployments PR uses latest bundles

### DIFF
--- a/hack/update-bundles.sh
+++ b/hack/update-bundles.sh
@@ -91,6 +91,9 @@ for b in $BUNDLES; do
     # No push needed
     echo "Policy bundle $push_repo:$tag exists already, no push needed"
 
+    # Skip building and pushing a new bundle, but ensure the infra-deployments PR uses
+    # the latest built
+    [ $b != "pipeline" ] && pr_params="$pr_params $(ecp_source $b) $push_repo:$tag"
   else
     # Push needed
     echo "Pushing policy bundle $push_repo:$tag now"


### PR DESCRIPTION
If two commits are merged in this repo within a given time window, and one updates only data while the other updates only policy, then one of those may not land on the infra-deployments PR.

This commit fixes the issue by always passing all the bundle references to the pr-infra-deployments script.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>