### PR TITLE
make install command on a newline

### DIFF
--- a/policy/release/artifacthub-pkg.yml
+++ b/policy/release/artifacthub-pkg.yml
@@ -9,7 +9,9 @@ readme: |
   are a work in progress and not yet production ready.
 install: |
   `conftest pull oci::https://quay.io/hacbs-contract/ec-release-policy:latest`
+
   Configure your org-specific `--data` as necessary from [data/](https://github.com/hacbs-contract/ec-policies/tree/main/data)
+
   Run your conftest command: `conftest verify --data data/`
 homeURL: https://hacbs-contract.github.io/ec-policies/
 keywords:


### PR DESCRIPTION
There are three install instructions that are showing up on the same line. This separates them to make them more readable.