### PR TITLE
Show code as `package_name.rule_name` in docs

### DIFF
--- a/antora/docs/modules/ROOT/templates/_rules.hbs
+++ b/antora/docs/modules/ROOT/templates/_rules.hbs
@@ -19,7 +19,7 @@
 
 * Rule type: [rule-type-indicator {{ warningOrFailure }}]#{{ toUpper warningOrFailure }}#
 * {{ toTitle warningOrFailure }} message: `{{ failureMsg }}`
-* Code: `{{ shortName }}`
+* Code: `{{ packageInfo.shortName }}.{{ shortName }}`
 {{#if effectiveOn}}
 * Effective from: `{{ effectiveOn }}`{{/if}}
 * https://github.com/hacbs-contract/ec-policies/blob/main/{{ file }}#L{{ row }}[Source, window="_blank"]


### PR DESCRIPTION
Now that we show the code that way in the ec output it's much better to do the same in the docs.