### PR TITLE
Rule collection improvements

### DIFF
--- a/antora/docs/modules/ROOT/pages/authoring.adoc
+++ b/antora/docs/modules/ROOT/pages/authoring.adoc
@@ -35,16 +35,20 @@ rule.
   `custom.rule_data.allowed_registry_prefixes`, allowing a single source of truth for policy rule
   evaluation and documentation. For best results, each key in the `custom.rule_data` object
   should be a noun.
-* `custom.collection`: A list of strings representing a list of rule collections
+* `custom.collections`: A list of strings representing a list of rule collections
   that the policy rule is included in.
 
 The annotations must be defined at the `rule` https://www.openpolicyagent.org/docs/latest/annotations/#scope[scope].
 
 == Package annotations
 
-The use of package annotations is constrained to documenting the rule
-collections for the purposes of generating the documentation. Within a package
-named `policy.<kind>.<collection>` these annotations can be set:
+Package annotations can be used to give a title and description to a package.
+Use the package name "policy.<kind>.collection.<collectionName>" in an otherwise
+empty package for collection annotations.
 
 * `title`: (required) short description of the rule collection.
 * `description`: (required) descriptive information about the rule collection.
+
+See Open Policy Agent's
+https://www.openpolicyagent.org/docs/latest/annotations/[documentation] for
+further reference on annotations.

--- a/antora/docs/modules/ROOT/pages/authoring.adoc
+++ b/antora/docs/modules/ROOT/pages/authoring.adoc
@@ -5,7 +5,7 @@
 This document is meant to assist policy authors in creating and maintaining the policy rules
 defined in this repository.
 
-== Annotations
+== Rule annotations
 
 Policy rules must contain certain https://www.openpolicyagent.org/docs/latest/annotations[annotations] that describe additional information about the
 rule.
@@ -35,5 +35,16 @@ rule.
   `custom.rule_data.allowed_registry_prefixes`, allowing a single source of truth for policy rule
   evaluation and documentation. For best results, each key in the `custom.rule_data` object
   should be a noun.
+* `custom.collection`: A list of strings representing a list of rule collections
+  that the policy rule is included in.
 
 The annotations must be defined at the `rule` https://www.openpolicyagent.org/docs/latest/annotations/#scope[scope].
+
+== Package annotations
+
+The use of package annotations is constrained to documenting the rule
+collections for the purposes of generating the documentation. Within a package
+named `policy.<kind>.<collection>` these annotations can be set:
+
+* `title`: (required) short description of the rule collection.
+* `description`: (required) descriptive information about the rule collection.

--- a/antora/docs/modules/ROOT/templates/policy_configuration.hbs
+++ b/antora/docs/modules/ROOT/templates/policy_configuration.hbs
@@ -194,49 +194,6 @@ file:
 }
 ----
 
-=== Available collections
-
-[cols="2,6"]
-|===
-|*Name*
-|*Description*
-
-| `minimal`
-a| Includes a minimal set of policy rules to ensure the build pipeline is
-functioning as expected, and able to produce signed attestations of the
-expected type.
-
-{{> rule_links releaseCollections.minimal}}
-
-| `slsa1`
-a| Includes policy rules required to meet SLSA Level 1.
-
-{{> rule_links releaseCollections.slsa1}}
-
-| `slsa2`
-a| Includes policy rules required to meet SLSA Level 2. Special attention must
-be given to two requirements which are not covered by the policy rules in this
-collection. The first is "Provenance - Authenticated" which is expected to be
-performed when fetching the attestation via cosign or ec-cli. The second
-requirement is "Provenace - Service Generated" which is a little more complex
-to verify. By meeting both the "Provenance - Authenticated" AND "Build - Build
-Service" requirements, we can have some confidence that this requirement is met
-since Chains is a service that generates signed attestations with data obtained
-from the build service (Tekton Pipelines).
-
-{{> rule_links releaseCollections.slsa2}}
-
-| `slsa3`
-a| Includes policy rules required to meet SLSA Level 3. This is currently a
-work in progress and functionally the same as the slsa2 collection.
-
-{{> rule_links releaseCollections.slsa3}}
-
-|===
-
-Policy rules may specify a `custom.collections` metadata attribute as a list of
-strings. Each string represents a collection the policy rule is included in.
-
 == The `non_blocking_checks` field
 
 The `non_blocking_checks` configuration option, previously used to skip rules

--- a/antora/docs/modules/ROOT/templates/release_policy.hbs
+++ b/antora/docs/modules/ROOT/templates/release_policy.hbs
@@ -4,6 +4,23 @@
 
 These rules are applied to pipeline run attestations associated with container images built by HACBS
 
+== Available rule collections
+
+[cols="2,6"]
+|===
+|*Name*
+|*Description*
+
+{{#each releaseCollections }}
+| `{{ title }}`
+a| {{ description }}
+
+{{> rule_links rules }}
+
+{{/each}}
+
+|===
+
 {{#each releaseAnnotations}}
 {{> rules }}
 {{/each}}

--- a/antora/ec-policies-antora-extension/package-lock.json
+++ b/antora/ec-policies-antora-extension/package-lock.json
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@zregvart/opa-inspect": {
-      "version": "0.49.0-22100ad",
-      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.49.0-22100ad.tgz",
-      "integrity": "sha512-tCDEs0ho3FghZipSkEbLVsdHx/v0IRj0PfRoFqmsvJvvHyyHlwmXwAjpFnB5xSsuv6urMs1v/IzCr+w07obCKg==",
+      "version": "0.49.0-6b587e0",
+      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.49.0-6b587e0.tgz",
+      "integrity": "sha512-BiphZG8xjEozeFldYc43NkLoPx/Y7cw46PCQoCWzPHKU/Z7cjup6bQo1ojn4TfhiDF6Qhm1fZdgHvY3RnfgG5Q==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -26,9 +26,9 @@
   },
   "dependencies": {
     "@zregvart/opa-inspect": {
-      "version": "0.49.0-22100ad",
-      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.49.0-22100ad.tgz",
-      "integrity": "sha512-tCDEs0ho3FghZipSkEbLVsdHx/v0IRj0PfRoFqmsvJvvHyyHlwmXwAjpFnB5xSsuv6urMs1v/IzCr+w07obCKg=="
+      "version": "0.49.0-6b587e0",
+      "resolved": "https://registry.npmjs.org/@zregvart/opa-inspect/-/opa-inspect-0.49.0-6b587e0.tgz",
+      "integrity": "sha512-BiphZG8xjEozeFldYc43NkLoPx/Y7cw46PCQoCWzPHKU/Z7cjup6bQo1ojn4TfhiDF6Qhm1fZdgHvY3RnfgG5Q=="
     }
   }
 }

--- a/policy/release/collection/minimal.rego
+++ b/policy/release/collection/minimal.rego
@@ -1,0 +1,8 @@
+#
+# METADATA
+# title: minimal
+# description: |-
+#   Includes a minimal set of policy rules to ensure the build pipeline is
+#   functioning as expected, and able to produce signed attestations of the
+#   expected type.
+package policy.release.collection.minimal

--- a/policy/release/collection/slsa1.rego
+++ b/policy/release/collection/slsa1.rego
@@ -1,0 +1,6 @@
+#
+# METADATA
+# title: slsa1
+# description: |-
+#   Includes policy rules required to meet SLSA Level 1.
+package policy.release.collection.slsa1

--- a/policy/release/collection/slsa2.rego
+++ b/policy/release/collection/slsa2.rego
@@ -1,0 +1,14 @@
+#
+# METADATA
+# title: slsa2
+# description: |-
+#   Includes policy rules required to meet SLSA Level 2. Special attention must
+#   be given to two requirements which are not covered by the policy rules in this
+#   collection. The first is "Provenance - Authenticated" which is expected to be
+#   performed when fetching the attestation via cosign or ec-cli. The second
+#   requirement is "Provenace - Service Generated" which is a little more complex
+#   to verify. By meeting both the "Provenance - Authenticated" AND "Build - Build
+#   Service" requirements, we can have some confidence that this requirement is met
+#   since Chains is a service that generates signed attestations with data obtained
+#   from the build service (Tekton Pipelines).
+package policy.release.collection.slsa2

--- a/policy/release/collection/slsa3.rego
+++ b/policy/release/collection/slsa3.rego
@@ -1,0 +1,7 @@
+#
+# METADATA
+# title: slsa3
+# description: |-
+#   Includes policy rules required to meet SLSA Level 3. This is currently a
+#   work in progress and functionally the same as the slsa2 collection.
+package policy.release.collection.slsa3


### PR DESCRIPTION
Introduces empty Rego packages to document the rule collections, these are in `policy.release.<collection>` package, but to reduce the release policy directory, placed in `policy/release/collection` directory.

The rule collection table has been moved to Release Policy documentation.

Ref. https://issues.redhat.com/browse/HACBS-1749