### PR TITLE
initial policy for task definitions

### DIFF
--- a/policy/task/kind.rego
+++ b/policy/task/kind.rego
@@ -1,0 +1,41 @@
+#
+# METADATA
+# title: Task definition kind checks
+# description: |-
+#   Task definition kind check
+#
+package policy.task.kind
+
+import future.keywords.contains
+import future.keywords.if
+
+import data.lib
+
+expected_kind := "Task"
+
+# METADATA
+# title: Input data has unexpected kind
+# description: |-
+#   Check to confirm the input data has the kind "Task"
+# custom:
+#   short_name: unexpected_kind
+#   failure_msg: Unexpected kind '%s'
+#
+deny contains result if {
+	input.kind
+	expected_kind != input.kind
+	result := lib.result_helper(rego.metadata.chain(), [input.kind])
+}
+
+# METADATA
+# title: Input data has kind defined
+# description: |-
+#   Check to confirm the input data has the kind field
+# custom:
+#   short_name: kind_not_found
+#   failure_msg: Required field 'kind' not found
+#
+deny contains result if {
+	not input.kind
+	result := lib.result_helper(rego.metadata.chain(), [])
+}

--- a/policy/task/kind_test.rego
+++ b/policy/task/kind_test.rego
@@ -1,0 +1,23 @@
+package policy.task.kind
+
+import data.lib
+
+test_unexpected_kind {
+	lib.assert_equal(deny, {{
+		"code": "kind.unexpected_kind",
+		"msg": "Unexpected kind 'Foo'",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input.kind as "Foo"
+}
+
+test_expected_kind {
+	lib.assert_empty(deny) with input as {"kind": "Task"}
+}
+
+test_kind_not_found {
+	lib.assert_equal(deny, {{
+		"code": "kind.kind_not_found",
+		"msg": "Required field 'kind' not found",
+		"effective_on": "2022-01-01T00:00:00Z",
+	}}) with input as {"bad": "Foo"}
+}


### PR DESCRIPTION
This is to get started on a policy for task definitions. Starting with a basic `kind` check.