### PR TITLE
Update docs for java policy with acceptable tasks

### DIFF
--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -5,11 +5,7 @@
 #   This package contains a rule to confirm that all Java dependencies
 #   were rebuilt in house rather than imported directly from potentially
 #   untrusted respositories.
-#   The result must be reported by a Task that has been loaded from an
-#   acceptable Tekton Bundle.
-#   See xref:release_policy.adoc#attestation_task_bundle_package[Task bundle checks].
-#   If the result is missing or provided via a task loaded from unacceptable no
-#   issue is reported.
+#   If the result is missing no violation is reported.
 #
 package policy.release.java
 

--- a/policy/release/java_test.rego
+++ b/policy/release/java_test.rego
@@ -27,16 +27,6 @@ test_has_foreign {
 	lib.assert_equal(deny, expected) with input.attestations as attestations
 }
 
-test_unacceptable_bundle {
-	attestations := [lib.att_mock_helper_ref(
-		lib.java_sbom_component_count_result_name,
-		{"redhat": 12, "rebuilt": 42},
-		"java-task-1",
-		"registry.img/unacceptable@sha256:digest",
-	)]
-	lib.assert_empty(deny) with input.attestations as attestations
-}
-
 test_missing_rule_data {
 	expected := {{
 		"code": "java.missing_rule_data",


### PR DESCRIPTION
This was missed in https://github.com/hacbs-contract/ec-policies/pull/297

The removed test didn't do anything. It produced no violations because the expected result was provided.