### PR TITLE
Use image source revision to deduce tag

### DIFF
--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -41,7 +41,7 @@ function oci_source() {
   trap cleanup RETURN
   skopeo inspect --raw  "docker://${img}" > "${manifest}"
   revision="$(jq -r '.annotations["org.opencontainers.image.revision"]' "${manifest}")"
-  if [[ -n "${revision}" && "${revision}" != null ]]; then
+  if [[ -n "${revision}" && "${revision}" != "null" ]]; then
     img="${img/:latest/:git-${revision}}"
   fi
   digest="$(sha256sum "${manifest}" | awk '{print $1}')"


### PR DESCRIPTION
This adds the image source revision, `org.opencontainers.image.revision` annotation to the Rego OCI bundle's manifest and uses it to deduce the alternate tag for the `latest` tag of an image when updating the resources in infra-deployments.

We need to keep the source revision (git commit id) within the bundle because not all commits end up pushing an updated bundle. So when we run the update of infra-deployment resources we do not know which commit id-based tag corresponds to the `latest` tag of the Rego OCI bundle we wish to update to.

An alternative to list all tags, fetch manifests and compare those with the `latest` tag is overly expensive (by number of requests) and requires authentication against quay.io to fetch a manifest by tag.

Ref. https://issues.redhat.com/browse/HACBS-1820