### PR TITLE
Less hard line breaks in rule descriptions

### DIFF
--- a/policy/pipeline/basic.rego
+++ b/policy/pipeline/basic.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: Pipeline definition sanity checks
-# description: |-
+# description: >-
 #   Currently there is just a check to confirm the input
 #   appears to be a Pipeline definition. We may add additional
 #   sanity checks in future.
@@ -21,7 +21,7 @@ expected_kind := "Pipeline"
 
 # METADATA
 # title: Input data has unexpected kind
-# description: |-
+# description: >-
 #   A sanity check to confirm the input data has the kind "Pipeline"
 # custom:
 #   short_name: unexpected_kind

--- a/policy/pipeline/required_tasks.rego
+++ b/policy/pipeline/required_tasks.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   HACBS expects that certain Tekton tasks are executed during image builds.
 #   This package includes policy rules to confirm that the pipeline definition
 #   includes the required Tekton tasks.
@@ -16,7 +16,7 @@ import data.lib.tkn
 
 # METADATA
 # title: No tasks in Pipeline
-# description: |-
+# description: >-
 #   This policy enforces that at least one Task is present in the Pipeline
 #   definition.
 # custom:
@@ -30,7 +30,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing required pipeline tasks
-# description: |-
+# description: >-
 #   This policy warns if a task list does not exist in the acceptable_bundles.yaml file
 # custom:
 #   short_name: missing_required_pipeline_task
@@ -43,7 +43,7 @@ warn contains result if {
 
 # METADATA
 # title: Missing required task
-# description: |-
+# description: >-
 #   This policy enforces that the required set of tasks are included
 #   in the Pipeline definition.
 # custom:
@@ -62,7 +62,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing future required task
-# description: |-
+# description: >-
 #   This policy warns when a task that will be required in the future
 #   was not included in the Pipeline definition.
 # custom:
@@ -82,7 +82,7 @@ warn contains result if {
 
 # METADATA
 # title: Missing required tasks data
-# description: |-
+# description: >-
 #   The policy rules in this package require the required-tasks data to be provided.
 # custom:
 #   short_name: missing_required_data

--- a/policy/pipeline/task_bundle.rego
+++ b/policy/pipeline/task_bundle.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   To be able to reproduce and audit builds accurately it's important
 #   to know exactly what happens during the build. To do this
 #   Enterprise Contract requires that all tasks are defined in a set of
@@ -20,7 +20,7 @@ import data.lib.bundles
 
 # METADATA
 # title: Task bundle was not used or is not defined
-# description: |-
+# description: >-
 #   Check for existence of a task bundle. Enforcing this rule will
 #   fail the contract if the task is not called from a bundle.
 # custom:
@@ -34,7 +34,7 @@ deny contains result if {
 
 # METADATA
 # title: Task bundle reference is empty
-# description: |-
+# description: >-
 #   Check for a valid task bundle reference being used.
 # custom:
 #   short_name: empty_task_bundle_reference
@@ -47,7 +47,7 @@ deny contains result if {
 
 # METADATA
 # title: Unpinned task bundle reference
-# description: |-
+# description: >-
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   is pinned to a digest.
 # custom:
@@ -61,7 +61,7 @@ warn contains result if {
 
 # METADATA
 # title: Task bundle is out of date
-# description: |-
+# description: >-
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   is the most recent acceptable one. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
@@ -79,7 +79,7 @@ warn contains result if {
 
 # METADATA
 # title: Task bundle is not acceptable
-# description: |-
+# description: >-
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   are acceptable given the tracked effective_on date. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
@@ -97,7 +97,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing required data
-# description: |-
+# description: >-
 #   The policy rules in this package require the task-bundles data to be provided.
 # custom:
 #   short_name: missing_required_data

--- a/policy/release/attestation_task_bundle.rego
+++ b/policy/release/attestation_task_bundle.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: Task bundle checks
-# description: |-
+# description: >-
 #   To be able to reproduce and audit builds accurately it's important
 #   to know exactly what happened during the build. To do this
 #   Enterprise Contract requires that all tasks are defined in a set of
@@ -17,7 +17,7 @@ import data.lib.bundles
 
 # METADATA
 # title: Task bundle was not used or is not defined
-# description: |-
+# description: >-
 #   Check for existence of a task bundle. Enforcing this rule will
 #   fail the contract if the task is not called from a bundle.
 # custom:
@@ -33,7 +33,7 @@ deny[result] {
 
 # METADATA
 # title: Task bundle reference is empty
-# description: |-
+# description: >-
 #   Check for a valid task bundle reference being used.
 # custom:
 #   short_name: empty_task_bundle_reference
@@ -48,7 +48,7 @@ deny[result] {
 
 # METADATA
 # title: Unpinned task bundle reference
-# description: |-
+# description: >-
 #   Check if the Tekton Bundle used for the Tasks in the Pipeline definition
 #   is pinned to a digest.
 # custom:
@@ -62,7 +62,7 @@ warn[result] {
 
 # METADATA
 # title: Task bundle is out of date
-# description: |-
+# description: >-
 #   Check if the Tekton Bundle used for the Tasks in the attestation
 #   is the most recent acceptable one. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
@@ -80,7 +80,7 @@ warn[result] {
 
 # METADATA
 # title: Task bundle is not acceptable
-# description: |-
+# description: >-
 #   Check if the Tekton Bundle used for the Tasks in the attestation
 #   are acceptable given the tracked effective_on date. See the list of acceptable
 #   task bundles at xref:acceptable_bundles.adoc#_task_bundles[Acceptable Bundles] or look at
@@ -98,7 +98,7 @@ deny[result] {
 
 # METADATA
 # title: Missing required data
-# description: |-
+# description: >-
 #   The policy rules in this package require the task-bundles data to be provided.
 # custom:
 #   short_name: missing_required_data

--- a/policy/release/attestation_type.rego
+++ b/policy/release/attestation_type.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   Sanity checks related to the format of the image build's attestation.
 #
 package policy.release.attestation_type
@@ -13,7 +13,7 @@ import data.lib
 
 # METADATA
 # title: Unknown attestation type found
-# description: |-
+# description: >-
 #   A sanity check to confirm the attestation found for the image has a known
 #   attestation type.
 # custom:
@@ -31,7 +31,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing pipelinerun attestation
-# description: >
+# description: >-
 #   At least one PipelineRun attestation must be present.
 # custom:
 #   short_name: missing_pipelinerun_attestation

--- a/policy/release/authorization.rego
+++ b/policy/release/authorization.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   This package contains rules to check that the image is signed-off
 #   for release. There are different ways of providing that sign-off
 #   authorization.
@@ -17,7 +17,7 @@ import data.lib
 
 # METADATA
 # title: Authorization does not exist
-# description: |-
+# description: >-
 #   Enterprise Contract verifies if the build was authorized
 # custom:
 #   short_name: disallowed_no_authorization
@@ -29,7 +29,7 @@ deny contains result if {
 
 # METADATA
 # title: Authorized commit does not match
-# description: |-
+# description: >-
 #   Enterprise Contract verifies if an authorized commit was used as the source of a build
 # custom:
 #   short_name: disallowed_commit_does_not_match
@@ -43,7 +43,7 @@ deny contains result if {
 
 # METADATA
 # title: Authorized repo url does not match
-# description: |-
+# description: >-
 #   Enterprise Contract verifies if an authorized repo url was used to build an image
 # custom:
 #   short_name: disallowed_repo_url_does_not_match

--- a/policy/release/base_image_registries.rego
+++ b/policy/release/base_image_registries.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: Base image checks
-# description: |-
+# description: >-
 #   This package is responsible for verifying the base (parent) images
 #   reported in the attestation are acceptable.
 #
@@ -15,7 +15,7 @@ import data.lib
 
 # METADATA
 # title: Restrict registry of base images
-# description: |-
+# description: >-
 #   The base images used when building a container image must come from a known set
 #   of trusted registries to reduce potential supply chain attacks. This policy
 #   defines trusted registries as registries that are fully maintained by Red Hat
@@ -34,7 +34,7 @@ deny contains result if {
 
 # METADATA
 # title: Base images must be provided
-# description: |-
+# description: >-
 #   The attestation must provide the expected information about which base images
 #   were used during the build process.
 # custom:
@@ -55,7 +55,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing rule data
-# description: |-
+# description: >-
 #   The policy rules in this package require the allowed_registry_prefixes
 #   rule data to be provided.
 # custom:

--- a/policy/release/buildah_build_task.rego
+++ b/policy/release/buildah_build_task.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: Buildah build task
-# description: |-
+# description: >-
 #   This package is responsible for verifying the buildah build task
 #
 package policy.release.buildah_build_task
@@ -14,7 +14,7 @@ import data.lib
 
 # METADATA
 # title: Dockerfile param not included
-# description: |-
+# description: >-
 #   This policy verifies that there is a dockerfile parameter
 # custom:
 #   short_name: dockerfile_param_not_included
@@ -28,7 +28,7 @@ deny contains result if {
 
 # METADATA
 # title: Dockerfile param external source
-# description: |-
+# description: >-
 #   This policy verifies that the dockerfile is not an external source
 # custom:
 #   short_name: dockerfile_param_external_source

--- a/policy/release/collection/minimal.rego
+++ b/policy/release/collection/minimal.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: minimal
-# description: |-
+# description: >-
 #   Includes a minimal set of policy rules to ensure the build pipeline is
 #   functioning as expected, and able to produce signed attestations of the
 #   expected type.

--- a/policy/release/collection/slsa1.rego
+++ b/policy/release/collection/slsa1.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
 # title: slsa1
-# description: |-
+# description: >-
 #   Includes policy rules required to meet SLSA Level 1.
 package policy.release.collection.slsa1

--- a/policy/release/collection/slsa2.rego
+++ b/policy/release/collection/slsa2.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: slsa2
-# description: |-
+# description: >-
 #   Includes policy rules required to meet SLSA Level 2. Special attention must
 #   be given to two requirements which are not covered by the policy rules in this
 #   collection. The first is "Provenance - Authenticated" which is expected to be

--- a/policy/release/collection/slsa3.rego
+++ b/policy/release/collection/slsa3.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: slsa3
-# description: |-
+# description: >-
 #   Includes policy rules required to meet SLSA Level 3. This is currently a
 #   work in progress and functionally the same as the slsa2 collection.
 package policy.release.collection.slsa3

--- a/policy/release/hermetic_build_task.rego
+++ b/policy/release/hermetic_build_task.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   This package verifies the build task in the attestation was invoked
 #   with the expected parameters to perform a hermetic build.
 #
@@ -15,7 +15,7 @@ import data.lib.tkn
 
 # METADATA
 # title: hermetic_build_task
-# description: |-
+# description: >-
 #   This policy verifies the build task in the PipelineRun attestation
 #   was invoked with the proper parameters to make the build process
 #   hermetic.

--- a/policy/release/java.rego
+++ b/policy/release/java.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: Java dependency checks
-# description: |-
+# description: >-
 #   This package contains a rule to confirm that all Java dependencies
 #   were rebuilt in house rather than imported directly from potentially
 #   untrusted respositories.
@@ -17,7 +17,7 @@ import data.lib
 
 # METADATA
 # title: Prevent Java builds from depending on foreign dependencies
-# description: |-
+# description: >-
 #   The SBOM_JAVA_COMPONENTS_COUNT TaskResult finds dependencies that have
 #   originated from foreign repositories, i.e. ones that are not rebuilt or
 #   redhat.
@@ -33,7 +33,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing rule data
-# description: |-
+# description: >-
 #   The policy rules in this package require the allowed_java_component_sources
 #   rule data to be provided.
 # custom:

--- a/policy/release/slsa_build_build_service.rego
+++ b/policy/release/slsa_build_build_service.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: SLSA - Build - Build Service
-# description: |-
+# description: >-
 #   The SLSA requirement states the following:
 #
 #   "All build steps ran using some build service, not on a
@@ -20,7 +20,7 @@ import data.lib
 
 # METADATA
 # title: Builder ID exists
-# description: |-
+# description: >-
 #   The attestation attribute predicate.builder.id is set.
 # custom:
 #   short_name: missing_builder_id
@@ -37,7 +37,7 @@ deny contains result if {
 
 # METADATA
 # title: Build service used
-# description: |-
+# description: >-
 #   The attestation attribute predicate.builder.id is set to one
 #   of the values in data.rule_data.allowed_builder_ids, e.g.
 #   "https://tekton.dev/chains/v2".

--- a/policy/release/slsa_build_scripted_build.rego
+++ b/policy/release/slsa_build_scripted_build.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: SLSA - Build - Scripted Build
-# description: |-
+# description: >-
 #   The SLSA requirement states the following:
 #
 #   "All build steps were fully defined in some sort of “build script”.
@@ -22,7 +22,7 @@ import data.lib.tkn
 
 # METADATA
 # title: Build task contains steps
-# description: |-
+# description: >-
 #   The attestation attribute predicate.buildConfig.tasks.steps is not
 #   empty of the pipeline task responsible for building the image.
 # custom:
@@ -42,7 +42,7 @@ deny contains result if {
 
 # METADATA
 # title: Build task missing
-# description: |-
+# description: >-
 #   The attestations must contain a build task with the expected
 #   IMAGE_DIGEST and IMAGE_URL results.
 # custom:
@@ -61,7 +61,7 @@ deny contains result if {
 
 # METADATA
 # title: Mismatch subject
-# description: |-
+# description: >-
 #   The subject of the attestations must match the IMAGE_DIGEST and
 #   IMAGE_URL values from the build task.
 # custom:

--- a/policy/release/slsa_provenance_available.rego
+++ b/policy/release/slsa_provenance_available.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: SLSA - Provenance - Available
-# description: |-
+# description: >-
 #   The SLSA Provenance Available requirement states the following:
 #
 #   "The provenance is available to the consumer in a format that the consumer accepts. The
@@ -20,7 +20,7 @@ import data.lib
 
 # METADATA
 # title: Attestation predicate type
-# description: |-
+# description: >-
 #   The predicateType field of the attestation must indicate the in-toto SLSA Provenance format
 #   was used to attest the PipelineRun.
 # custom:

--- a/policy/release/slsa_source_version_controlled.rego
+++ b/policy/release/slsa_source_version_controlled.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: SLSA - Source - Version Controlled
-# description: |-
+# description: >-
 #   The SLSA requirement states the following:
 #
 #   "Every change to the source is tracked in a version control system
@@ -34,7 +34,7 @@ import data.lib
 
 # METADATA
 # title: Material format
-# description: |-
+# description: >-
 #   At least one entry in the predicate.materials array of the attestation contains
 #   the expected attributes: uri and digest.sha1.
 # custom:
@@ -53,7 +53,7 @@ deny contains result if {
 
 # METADATA
 # title: Material from a git repository
-# description: |-
+# description: >-
 #   Each entry in the predicate.materials array of the attestation uses
 #   a git URI.
 # custom:
@@ -72,7 +72,7 @@ deny contains result if {
 
 # METADATA
 # title: Material with git commit digest
-# description: |-
+# description: >-
 #   Each entry in the predicate.materials array of the attestation includes
 #   a SHA1 digest which corresponds to a git commit.
 # custom:

--- a/policy/release/step_image_registries.rego
+++ b/policy/release/step_image_registries.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   This package contains a rule to ensure that each task in the image's
 #   build pipeline ran using a container image from a known and presumably
 #   trusted source.
@@ -15,7 +15,7 @@ import data.lib
 
 # METADATA
 # title: Task steps ran on container images that are disallowed
-# description: |-
+# description: >-
 #   Enterprise Contract has a list of allowed registry prefixes. Each step in each
 #   each TaskRun must run on a container image with a url that matches one of the
 #   prefixes in the list.
@@ -36,7 +36,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing rule data
-# description: |-
+# description: >-
 #   The policy rules in this package require the allowed_step_image_registry_prefixes
 #   rule data to be provided.
 # custom:

--- a/policy/release/tasks.rego
+++ b/policy/release/tasks.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   Enterprise Contract expects that a set of tasks were included
 #   in the pipeline build for each image to be released.
 #   This package includes a set of rules to verify that the expected
@@ -25,7 +25,7 @@ import data.lib.tkn
 
 # METADATA
 # title: No tasks run
-# description: |-
+# description: >-
 #   This policy enforces that at least one Task is present in the PipelineRun
 #   attestation.
 # custom:
@@ -42,7 +42,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing required task
-# description: |-
+# description: >-
 #   This policy enforces that the required set of tasks are included
 #   in the PipelineRun attestation.
 # custom:
@@ -58,7 +58,7 @@ deny contains result if {
 
 # METADATA
 # title: Missing required pipeline tasks warning
-# description: |-
+# description: >-
 #   This policy warns if a task list does not exist in the acceptable_bundles.yaml file
 # custom:
 #   short_name: missing_required_pipeline_task_warning
@@ -70,7 +70,7 @@ warn contains result if {
 
 # METADATA
 # title: Missing future required task
-# description: |-
+# description: >-
 #   This policy warns when a task that will be required in the future
 #   was not included in the PipelineRun attestation.
 # custom:
@@ -87,7 +87,7 @@ warn contains result if {
 
 # METADATA
 # title: Missing required tasks data
-# description: |-
+# description: >-
 #   The policy rules in this package require the required-tasks data to be provided.
 # custom:
 #   short_name: missing_required_data

--- a/policy/release/test.rego
+++ b/policy/release/test.rego
@@ -1,6 +1,6 @@
 #
 # METADATA
-# description: |-
+# description: >-
 #   Enterprise Contract requires that each build was subjected
 #   to a set of tests and that those tests all passed. This package
 #   includes a set of rules to verify that.
@@ -19,7 +19,7 @@ import future.keywords.in
 
 # METADATA
 # title: No test data found
-# description: |-
+# description: >-
 #   None of the tasks in the pipeline included a HACBS_TEST_OUTPUT
 #   task result, which is where Enterprise Contract expects to find
 #   test result data.
@@ -37,7 +37,7 @@ deny[result] {
 
 # METADATA
 # title: Test data is missing the results key
-# description: |-
+# description: >-
 #   Each test result is expected to have a 'results' key. In at least
 #   one of the HACBS_TEST_OUTPUT task results this key was not present.
 # custom:
@@ -52,7 +52,7 @@ deny[result] {
 
 # METADATA
 # title: Unsupported result in test data
-# description: |-
+# description: >-
 #   This policy expects a set of known/supported results in the test data
 #   It is a failure if we encounter a result that is not supported.
 # custom:
@@ -78,7 +78,7 @@ deny[result] {
 
 # METADATA
 # title: Test result is FAILURE or ERROR
-# description: |-
+# description: >-
 #   Enterprise Contract requires that all the tests in the test results
 #   have a successful result. A successful result is one that isn't a
 #   "FAILURE" or "ERROR". This will fail if any of the tests failed and
@@ -94,7 +94,7 @@ deny[result] {
 
 # METADATA
 # title: Test was skipped
-# description: |-
+# description: >-
 #   Reports any test that has its result set to "SKIPPED".
 # custom:
 #   short_name: test_result_skipped
@@ -107,7 +107,7 @@ warn[result] {
 
 # METADATA
 # title: Test returned a warning
-# description: |-
+# description: >-
 #   Reports any test that has its result set to "WARNING".
 # custom:
 #   short_name: test_result_warning

--- a/policy/task/kind.rego
+++ b/policy/task/kind.rego
@@ -1,7 +1,7 @@
 #
 # METADATA
 # title: Task definition kind checks
-# description: |-
+# description: >-
 #   Task definition kind check
 #
 package policy.task.kind
@@ -15,7 +15,7 @@ expected_kind := "Task"
 
 # METADATA
 # title: Input data has unexpected kind
-# description: |-
+# description: >-
 #   Check to confirm the input data has the kind "Task"
 # custom:
 #   short_name: unexpected_kind
@@ -29,7 +29,7 @@ deny contains result if {
 
 # METADATA
 # title: Input data has kind defined
-# description: |-
+# description: >-
 #   Check to confirm the input data has the kind field
 # custom:
 #   short_name: kind_not_found


### PR DESCRIPTION
It's probably not super important, but it seems nicer to do it this way consistently, and it might make a difference if we do decide to render a text formatted version of the ec output.