### PR TITLE
Update release_policy and pipeline_policy page nav

### DIFF
--- a/antora/docs/modules/ROOT/nav.adoc
+++ b/antora/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,6 @@
 * xref:index.adoc[About Enterprise Contract]
-* xref:release_policy.adoc[Release Policy]
-* xref:pipeline_policy.adoc[Pipeline Policy]
+include::partial$release_policy_nav.adoc[]
+include::partial$pipeline_policy_nav.adoc[]
 * xref:acceptable_bundles.adoc[Acceptable Bundles]
 * xref:policy_bundles.adoc[Policy Bundles]
 * xref:policy_configuration.adoc[Policy Configuration]

--- a/antora/docs/modules/ROOT/partials/pipeline_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/pipeline_policy_nav.adoc
@@ -1,0 +1,7 @@
+* xref:pipeline_policy.adoc[Pipeline Policy]
+{{#each pipelineAnnotations}}
+    ** xref:pipeline_policy.adoc#{{this.0.packageInfo.shortName}}_package[{{this.0.packageInfo.title}}]
+    {{#each .}}
+        *** xref:pipeline_policy.adoc#{{anchor}}[{{title}}]
+    {{/each}}
+{{/each}}

--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -1,0 +1,26 @@
+* xref:release_policy.adoc[Release Policy]
+** xref:_available_rule_collections[Rule Collections]
+{{#each rulesCollection}}
+    *** xref:release_policy.adoc#{{this.title}}[{{this.title}}]
+{{/each}}
+
+** Release Annotations
+{{#each releaseAnnotations}}
+        {{#if this.title}}
+            *** {{this.title }}
+        {{else}}
+            *** xref:{{ this.0.packageInfo.shortNamespace }}_policy.adoc#{{this.0.packageInfo.shortName}}_package[{{this.0.packageInfo.title}}]
+            {{#each .}}
+                {{#if title}}
+                    **** xref:{{ packageInfo.shortNamespace }}_policy.adoc#{{ anchor }}[{{ title }}]
+                {{/if}}
+            {{/each}}
+        {{/if}}
+{{/each}}
+
+{{#if pipelineCollection}}
+    * Pipeline Collections
+    {{#each pipelineCollection}}
+        ** {{this.title}}
+{{/each}}
+{{/if}}

--- a/antora/docs/modules/ROOT/templates/_rule_links.hbs
+++ b/antora/docs/modules/ROOT/templates/_rule_links.hbs
@@ -1,5 +1,5 @@
 Rules included:
 
-{{#each this}}
+{{#each .}}
 - xref:{{ pkgNamespace }}_policy.adoc#{{ anchor }}[{{ pkgTitle }}: {{ title }}]
 {{/each}}

--- a/antora/docs/modules/ROOT/templates/acceptable_bundles.hbs
+++ b/antora/docs/modules/ROOT/templates/acceptable_bundles.hbs
@@ -10,7 +10,7 @@ xref:release_policy#unacceptable_task_bundle[release] and
 xref:pipeline_policy#unacceptable_task_bundle[policy] rules where this list is used.
 
 The list of acceptable bundles is time based. A bundle that is acceptable today is not
-necessarily acceptable tommorrow. The list below may contain bundles that are "too old"
+necessarily acceptable tomorrow. The list below may contain bundles that are "too old"
 and no longer acceptable. The reason for this behavior is to allow users a certain
 period of time to upgrade to a newer bundle.
 

--- a/antora/docs/modules/ROOT/templates/release_policy.hbs
+++ b/antora/docs/modules/ROOT/templates/release_policy.hbs
@@ -12,7 +12,7 @@ These rules are applied to pipeline run attestations associated with container i
 |*Description*
 
 {{#each releaseCollections }}
-| `{{ title }}`
+| [#{{title}}]`{{ title }}`
 a| {{ description }}
 
 {{> rule_links rules }}


### PR DESCRIPTION
Updated navigation for release_policy and pipeline_policy pages as both had grown to contain large amounts of data. Navigation not benefits from fold out navigation in the side bar.