### PR TITLE
Add default cve config to rule_data file

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -20,3 +20,7 @@ rule_data:
   allowed_java_component_sources:
   - redhat
   - rebuilt
+
+  # Defaults for reference. Levels are "critical", "high", "medium", and "low".
+  #restrict_cve_security_levels: ["critical", "high"]
+  #warn_cve_security_levels: []


### PR DESCRIPTION
Show what the defaults are but leave them commented out. The idea is to make it easy for someone to modify the file to suit their preference, but avoid the possibility that the config values might obscure the real defaults.