### PR TITLE
Heading change

### DIFF
--- a/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
+++ b/antora/docs/modules/ROOT/partials/release_policy_nav.adoc
@@ -4,7 +4,7 @@
     *** xref:release_policy.adoc#{{this.title}}[{{this.title}}]
 {{/each}}
 
-** Release Annotations
+** Release Rules
 {{#each releaseAnnotations}}
         {{#if this.title}}
             *** {{this.title }}


### PR DESCRIPTION
Seems more appropriate to name this "Release Rules" than "Release Annotations".