### PR TITLE
Removes the `DEPLOY_KEY` secret

### DIFF
--- a/.github/workflows/push-bundles.yaml
+++ b/.github/workflows/push-bundles.yaml
@@ -37,7 +37,6 @@ jobs:
     - name: Push bundles
       env:
         EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
-        DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         APP_INSTALL_ID: 32872589
       run: |
         set -o errexit


### PR DESCRIPTION
As far as I can see this is no longer used.