### PR TITLE
Mention the built in defaults in rule data yaml

### DIFF
--- a/data/rule_data.yml
+++ b/data/rule_data.yml
@@ -20,3 +20,6 @@ rule_data:
   allowed_java_component_sources:
   - redhat
   - rebuilt
+
+  # See also the additional default rule data values defined in
+  # https://github.com/hacbs-contract/ec-policies/blob/main/policy/lib/rule_data.rego

--- a/policy/lib/rule_data.rego
+++ b/policy/lib/rule_data.rego
@@ -30,7 +30,9 @@ rule_data_defaults := {
 	"warned_tests_results": ["WARNING"],
 	#
 	# Used in release/cve.go
+	# Valid levels: "critical", "high", "medium", and "low"
 	"restrict_cve_security_levels": ["critical", "high"],
+	"warn_cve_security_levels": [],
 }
 
 # Returns the "first found" of the following:


### PR DESCRIPTION
Make it a little easier for users to know there are some other rule
data keys that they could override if they want to.

The initial motivation was to make it easier for users to be aware
of the two rule data keys related to the cve policy, since
customizing those is a thing that users might want to do. This is
documented in the rule itself, but I figure there's no harm in
making it discoverable in other ways.

Also set the default value of warn_cve_security_levels explicitly to
an empty list. It makes no functional difference, but it makes it
easier for someone reading the code to understand what is going on.

(This does bring up the question of why some keys have default
values in rule_data.rego and others don't, but let's consider that
later.)