### PR TITLE
Remove https from oci urls in automated pr

### DIFF
--- a/hack/update-infra-deployments.sh
+++ b/hack/update-infra-deployments.sh
@@ -50,7 +50,7 @@ function oci_source() {
   # sanity check
   diff <(skopeo inspect --raw "docker://${img_ref_tag}") <(skopeo inspect --raw "docker://${img_ref_digest}") >&2
   img_ref="${img}@sha256:${digest}"
-  echo "oci::https://${img_ref}"
+  echo "oci::${img_ref}"
 }
 
 function update_ecp_resources() {


### PR DESCRIPTION
The latest conftest update changes how the urls are split up and the https:// protocol in oci urls doesn't work any more.